### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-# Simple stuff modules should ignore
-*.iml
+# Modules get a copy of build.gradle as they are not allowed to have their own (for build security / sandboxing)
 build.gradle
+
+# IntelliJ
+*.iml
+
+# Eclipse
+.checkstyle
+.classpath
+.project
+.settings
+bin/
+build/


### PR DESCRIPTION
My Git was complaining about unversioned files in the `build` directory.  After poking around a bit, it looks like LightAndShadow has an older .gitignore that has since been replaced with a uniform file on most of the other modules (and that file ignores the `build` directory).  This PR is just to update LightAndShadow to use the newer file.