### PR TITLE
Issue #12 Adds a rasterizer to place L&S flora in world on world generation

### DIFF
--- a/src/main/java/org/terasology/las/LaSFloraRasterizer.java
+++ b/src/main/java/org/terasology/las/LaSFloraRasterizer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.las;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import org.terasology.core.world.generator.facets.FloraFacet;
+import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
+import org.terasology.core.world.generator.rasterizers.FloraType;
+import org.terasology.math.geom.BaseVector3i;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.utilities.procedural.WhiteNoise;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.Region;
+
+
+import java.util.List;
+import java.util.Map;
+
+public class LaSFloraRasterizer extends FloraRasterizer {
+    private final Map<FloraType, List<Block>> flora = Maps.newEnumMap(FloraType.class);
+    private Block air;
+
+    @Override
+    public void initialize() {
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        air = blockManager.getBlock(BlockManager.AIR_ID);
+
+        flora.put(FloraType.GRASS, ImmutableList.<Block>of(
+                blockManager.getBlock("core:TallGrass1"),
+                blockManager.getBlock("core:TallGrass2"),
+                blockManager.getBlock("core:TallGrass3")));
+
+        flora.put(FloraType.FLOWER, ImmutableList.<Block>of(
+                blockManager.getBlock("lightAndShadowResources:spadesCropSapling"),
+                blockManager.getBlock("lightAndShadowResources:heartsCropSapling"),
+                blockManager.getBlock("lightAndShadowResources:diamondsCropSapling"),
+                blockManager.getBlock("lightAndShadowResources:clubsCropSapling"),
+                blockManager.getBlock("lightAndShadowResources:unclaimedCropSapling")));
+
+
+        flora.put(FloraType.MUSHROOM, ImmutableList.<Block>of(
+                blockManager.getBlock("core:BigBrownShroom"),
+                blockManager.getBlock("core:BrownShroom"),
+                blockManager.getBlock("core:RedShroom")));
+    }
+
+
+    @Override
+    public void generateChunk(CoreChunk chunk, Region chunkRegion) {
+        super.generateChunk(chunk, chunkRegion);
+
+        FloraFacet facet = chunkRegion.getFacet(FloraFacet.class);
+
+        WhiteNoise noise = new WhiteNoise(chunk.getPosition().hashCode());
+
+        Map<BaseVector3i, FloraType> entries = facet.getRelativeEntries();
+        // check if some other rasterizer has already placed something here
+        entries.keySet().stream().filter(pos -> chunk.getBlock(pos).equals(air)).forEach(pos -> {
+
+            FloraType type = entries.get(pos);
+            List<Block> list = flora.get(type);
+            int blockIdx = Math.abs(noise.intNoise(pos.x(), pos.y(), pos.z())) % list.size();
+            Block block = list.get(blockIdx);
+            chunk.setBlock(pos, block);
+        });
+    }
+}

--- a/src/main/java/org/terasology/las/LaSWorldGenerator.java
+++ b/src/main/java/org/terasology/las/LaSWorldGenerator.java
@@ -16,20 +16,30 @@
 
 package org.terasology.las;
 
+import org.terasology.cities.BlockTheme;
 import org.terasology.cities.CityWorldGenerator;
+import org.terasology.cities.DefaultBlockType;
+import org.terasology.cities.SimpleBiomeProvider;
 import org.terasology.cities.bldg.Building;
 import org.terasology.cities.bldg.BuildingFacetProvider;
 import org.terasology.cities.blocked.BlockedAreaFacetProvider;
+import org.terasology.cities.deco.ColumnRasterizer;
+import org.terasology.cities.deco.DecorationFacetProvider;
+import org.terasology.cities.deco.SingleBlockRasterizer;
 import org.terasology.cities.door.DoorFacetProvider;
 import org.terasology.cities.door.SimpleDoorRasterizer;
 import org.terasology.cities.door.WingDoorRasterizer;
 import org.terasology.cities.fences.FenceFacetProvider;
 import org.terasology.cities.fences.SimpleFenceRasterizer;
+import org.terasology.cities.flora.FloraFacetProvider;
+import org.terasology.cities.flora.TreeFacetProvider;
 import org.terasology.cities.lakes.LakeFacetProvider;
 import org.terasology.cities.parcels.Parcel;
 import org.terasology.cities.parcels.ParcelFacetProvider;
+import org.terasology.cities.raster.standard.HollowBuildingPartRasterizer;
 import org.terasology.cities.raster.standard.RectPartRasterizer;
 import org.terasology.cities.raster.standard.RoundPartRasterizer;
+import org.terasology.cities.raster.standard.StaircaseRasterizer;
 import org.terasology.cities.roads.RoadFacetProvider;
 import org.terasology.cities.roads.RoadRasterizer;
 import org.terasology.cities.roof.ConicRoofRasterizer;
@@ -52,12 +62,15 @@ import org.terasology.cities.window.WindowFacetProvider;
 import org.terasology.commonworld.heightmap.HeightMap;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 //import org.terasology.core.world.generator.facetProviders.EnsureSpawnableChunkZeroProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
 
+import org.terasology.cities.SettlementEntityProvider;
 
+import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.spawner.Spawner;
@@ -71,6 +84,8 @@ import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
+import org.terasology.las.LaSFloraRasterizer;
+
 @RegisterWorldGenerator(id = "las", displayName = "Light & Shadow World")
 public class LaSWorldGenerator extends CityWorldGenerator {
 
@@ -80,6 +95,8 @@ public class LaSWorldGenerator extends CityWorldGenerator {
 
     @In
     private BlockManager blockManager;
+
+    private BlockTheme theme;
 
     /**
      * @param uri the uri
@@ -96,6 +113,92 @@ public class LaSWorldGenerator extends CityWorldGenerator {
 
     @Override
     protected WorldBuilder createWorld() {
-        return super.createWorld();
+        int seaLevel = 2;
+
+        theme = BlockTheme.builder(blockManager)
+                .register(DefaultBlockType.ROAD_FILL, "core:dirt")
+                .register(DefaultBlockType.ROAD_SURFACE, "core:Gravel")
+                .register(DefaultBlockType.LOT_EMPTY, "core:dirt")
+                .register(DefaultBlockType.BUILDING_WALL, "Cities:stonawall1")
+                .register(DefaultBlockType.BUILDING_FLOOR, "Cities:stonawall1dark")
+                .register(DefaultBlockType.BUILDING_FOUNDATION, "core:gravel")
+                .register(DefaultBlockType.TOWER_STAIRS, "core:CobbleStone")
+                .register(DefaultBlockType.ROOF_FLAT, "Cities:rooftiles2")
+                .register(DefaultBlockType.ROOF_HIP, "Cities:wood3")
+                .register(DefaultBlockType.ROOF_SADDLE, "Cities:wood3")
+                .register(DefaultBlockType.ROOF_DOME, "core:plank")
+                .register(DefaultBlockType.ROOF_GABLE, "core:plank")
+                .register(DefaultBlockType.SIMPLE_DOOR, BlockManager.AIR_ID)
+                .register(DefaultBlockType.WING_DOOR, BlockManager.AIR_ID)
+                .register(DefaultBlockType.WINDOW_GLASS, BlockManager.AIR_ID)
+                .register(DefaultBlockType.TOWER_WALL, "Cities:stonawall1")
+
+                // -- requires Fences module
+                .registerFamily(DefaultBlockType.FENCE, "Fences:Fence")
+                .registerFamily(DefaultBlockType.FENCE_GATE, BlockManager.AIR_ID)  // there is no fence gate :-(
+                .registerFamily(DefaultBlockType.TOWER_STAIRS, "core:CobbleStone:engine:stair")
+                .registerFamily(DefaultBlockType.BARREL, "StructuralResources:Barrel")
+                .registerFamily(DefaultBlockType.LADDER, "Core:Ladder")
+                .registerFamily(DefaultBlockType.PILLAR_BASE, "core:CobbleStone:StructuralResources:pillarBase")
+                .registerFamily(DefaultBlockType.PILLAR_MIDDLE, "core:CobbleStone:StructuralResources:pillar")
+                .registerFamily(DefaultBlockType.PILLAR_TOP, "core:CobbleStone:StructuralResources:pillarTop")
+                .registerFamily(DefaultBlockType.TORCH, "Core:Torch")
+
+                .build();
+
+        PerlinHumidityProvider.Configuration humidityConfig = new PerlinHumidityProvider.Configuration();
+        humidityConfig.octaves = 4;
+        humidityConfig.scale = 0.5f;
+
+        WorldBuilder worldBuilder = new WorldBuilder(CoreRegistry.get(WorldGeneratorPluginLibrary.class))
+                .setSeaLevel(seaLevel)
+                .addProvider(new SeaLevelProvider(seaLevel))
+                .addProvider(new InfiniteSurfaceHeightFacetProvider())
+                .addProvider(new SurfaceHeightFacetProvider())
+                .addProvider(new SurfaceToDensityProvider())
+                .addProvider(new BuildableTerrainFacetProvider())
+                .addProvider(new BlockedAreaFacetProvider())
+                .addProvider(new LakeFacetProvider())
+                .addProvider(new PerlinHumidityProvider(humidityConfig))
+                .addProvider(new SimpleBiomeProvider())
+                .addProvider(new SiteFacetProvider())
+                .addProvider(new TownWallFacetProvider())
+                .addProvider(new RoadFacetProvider())
+                .addProvider(new ParcelFacetProvider())
+                .addProvider(new FenceFacetProvider())
+                .addProvider(new WindowFacetProvider())
+                .addProvider(new DecorationFacetProvider())
+                .addProvider(new DoorFacetProvider())
+                .addProvider(new RoofFacetProvider())
+                .addProvider(new BuildingFacetProvider())
+                .addProvider(new SettlementFacetProvider())
+                .addProvider(new FloraFacetProvider())
+                .addProvider(new TreeFacetProvider())
+                .addRasterizer(new SolidRasterizer())
+                .addPlugins()
+                .addEntities(new SettlementEntityProvider())
+                .addRasterizer(new RoadRasterizer(theme))
+                .addRasterizer(new TownWallRasterizer(theme))
+                .addRasterizer(new SimpleFenceRasterizer(theme))
+                .addRasterizer(new RectPartRasterizer(theme))
+                .addRasterizer(new HollowBuildingPartRasterizer(theme))
+                .addRasterizer(new RoundPartRasterizer(theme))
+                .addRasterizer(new StaircaseRasterizer(theme))
+                .addRasterizer(new FlatRoofRasterizer(theme))
+                .addRasterizer(new SaddleRoofRasterizer(theme))
+                .addRasterizer(new PentRoofRasterizer(theme))
+                .addRasterizer(new HipRoofRasterizer(theme))
+                .addRasterizer(new ConicRoofRasterizer(theme))
+                .addRasterizer(new DomeRoofRasterizer(theme))
+                .addRasterizer(new SimpleWindowRasterizer(theme))
+                .addRasterizer(new RectWindowRasterizer(theme))
+                .addRasterizer(new SimpleDoorRasterizer(theme))
+                .addRasterizer(new WingDoorRasterizer(theme))
+                .addRasterizer(new SingleBlockRasterizer(theme))
+                .addRasterizer(new ColumnRasterizer(theme))
+                .addRasterizer(new LaSFloraRasterizer())
+                .addRasterizer(new TreeRasterizer());
+        return worldBuilder;
+        //return super.createWorld();
     }
 }


### PR DESCRIPTION
PR for Issue #12 -- adds a FloraGenerator for L&S-specific assets (listed in #11 and #43) and calls it on world generation, placing L&S flora throughout the world.

NOTE: Although this works now, the code is a bit redundant and I wasn't sure how to reduce redundancy while still getting the flora to spawn correctly, so any notes on that would be helpful 