### PR TITLE
Fix for flag stealing and scoring not working in headless server + client setup

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -54,7 +54,7 @@ public final class LASUtils {
     // The position near the team's base that player will be teleported to on choosing a team
     public static final Vector3f RED_TELEPORT_DESTINATION = new Vector3f(29, 12, 0);
     public static final Vector3f BLACK_TELEPORT_DESTINATION = new Vector3f(-29, 12, 0);
-
+    public static final String MAGIC_STAFF_URI = "LightAndShadowResources:magicStaff";
 
     private LASUtils() {
     }
@@ -98,5 +98,4 @@ public final class LASUtils {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/FlagParticleComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/FlagParticleComponent.java
@@ -20,15 +20,4 @@ import org.terasology.entitySystem.entity.EntityRef;
 
 public class FlagParticleComponent implements Component {
     public EntityRef particleEntity = EntityRef.NULL;
-
-    public FlagParticleComponent() {
-    }
-
-    public FlagParticleComponent(EntityRef particleEntity) {
-        this.particleEntity = particleEntity;
-    }
-
-    public EntityRef getParticleEntity() {
-        return particleEntity;
-    }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/HasFlagComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/HasFlagComponent.java
@@ -16,6 +16,8 @@
 package org.terasology.ligthandshadow.componentsystem.components;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.network.Replicate;
+import org.terasology.world.block.ForceBlockActive;
 import org.terasology.world.block.items.AddToBlockBasedItem;
 
 /**
@@ -23,14 +25,8 @@ import org.terasology.world.block.items.AddToBlockBasedItem;
  * flag in their inventory
  * String flag indicates the team of the flag being held
  */
-@AddToBlockBasedItem
+
 public class HasFlagComponent implements Component {
+    @Replicate
     public String flag;
-
-    public HasFlagComponent() {
-    }
-
-    public HasFlagComponent(String flag) {
-        this.flag = flag;
-    }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/AttackSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/AttackSystem.java
@@ -149,9 +149,16 @@ public class AttackSystem extends BaseComponentSystem {
 
     private void handleFlagPickup(EntityRef player, String flagTeam) {
         sendEventToClients(new FlagPickupEvent(player, flagTeam));
+        if (!player.hasComponent(HasFlagComponent.class)) {
+            player.addComponent(new HasFlagComponent());
+            player.getComponent(HasFlagComponent.class).flag = flagTeam;
+        }
     }
 
     private void handleFlagDrop(EntityRef player) {
+        if (player.hasComponent(HasFlagComponent.class)) {
+            player.removeComponent(HasFlagComponent.class);
+        }
         sendEventToClients(new FlagDropEvent(player));
     }
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientParticleSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientParticleSystem.java
@@ -23,7 +23,6 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.components.FlagParticleComponent;
-import org.terasology.ligthandshadow.componentsystem.components.HasFlagComponent;
 import org.terasology.ligthandshadow.componentsystem.events.FlagDropEvent;
 import org.terasology.ligthandshadow.componentsystem.events.FlagPickupEvent;
 import org.terasology.logic.location.Location;
@@ -42,17 +41,13 @@ public class ClientParticleSystem extends BaseComponentSystem {
 
         if (!player.hasComponent(FlagParticleComponent.class)) {
             EntityRef particleEntity = entityManager.create(LASUtils.getFlagParticle(team));
-            FlagParticleComponent particleComponent = new FlagParticleComponent(particleEntity);
-
             LocationComponent targetLoc = player.getComponent(LocationComponent.class);
             LocationComponent childLoc = particleEntity.getComponent(LocationComponent.class);
             childLoc.setWorldPosition(targetLoc.getWorldPosition());
             Location.attachChild(player, particleEntity);
             particleEntity.setOwner(player);
-            player.addOrSaveComponent(particleComponent);
-        }
-        if (!player.hasComponent(HasFlagComponent.class)) {
-            player.addComponent(new HasFlagComponent(team));
+            player.addComponent(new FlagParticleComponent());
+            player.getComponent(FlagParticleComponent.class).particleEntity = particleEntity;
         }
     }
 
@@ -65,9 +60,6 @@ public class ClientParticleSystem extends BaseComponentSystem {
                 particleEntity.destroy();
             }
             player.removeComponent(FlagParticleComponent.class);
-        }
-        if (player.hasComponent(HasFlagComponent.class)) {
-            player.removeComponent(HasFlagComponent.class);
         }
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -17,7 +17,6 @@ package org.terasology.ligthandshadow.componentsystem.controllers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
@@ -26,34 +25,23 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
-import org.terasology.ligthandshadow.componentsystem.components.HasFlagComponent;
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivateComponent;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
-import org.terasology.ligthandshadow.componentsystem.events.ScoreUpdateFromServerEvent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
-import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
-
 public class TeleporterSystem extends BaseComponentSystem {
     private static final Logger logger = LoggerFactory.getLogger(TeleporterSystem.class);
-    private static final String MAGIC_STAFF_URI = "LightAndShadowResources:magicStaff";
+
     @In
     InventoryManager inventoryManager;
     @In
     EntityManager entityManager;
-
-    private EntityBuilder builder;
-
-    // The position near the team's base that player will be teleported to on choosing a team
-    private static final Vector3f RED_TELEPORT_DESTINATION = new Vector3f(29, 12, 0);
-    private static final Vector3f BLACK_TELEPORT_DESTINATION = new Vector3f(-29, 12, 0);
 
     /* Depending on which teleporter the player chooses, they are set to that team
      * and teleported to that base */
@@ -74,7 +62,7 @@ public class TeleporterSystem extends BaseComponentSystem {
 
     private void handlePlayerTeleport(EntityRef player, String team) {
         player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
-        inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(MAGIC_STAFF_URI));
+        inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(LASUtils.MAGIC_STAFF_URI));
         setPlayerSkin(player, team);
     }
 


### PR DESCRIPTION
Moves code that adds `HasFlagComponent` to player to an Authority system, so that checks for player having `HasFlagComponent` are properly handled. 