### PR TITLE
[WIP] Update to how player skinning on team selection is handled

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -43,8 +43,9 @@ public final class LASUtils {
     public static final int GOAL_SCORE = 5;
     public static final String SPADES_PARTICLE = "lightAndShadowResources:blackFlagParticleEffect";
     public static final String HEARTS_PARTICLE = "lightAndShadowResources:redFlagParticleEffect";
-    public static final String BLACK_PAWN = "lightAndShadowResources:blackPawnPlayer";
-    public static final String RED_PAWN = "lightAndShadowResources:redPawnPlayer";
+    public static final String BLACK_PAWN_SKIN = "lightAndShadowResources:blackPawnPlayerSkin";
+    public static final String RED_PAWN_SKIN = "lightAndShadowResources:redPawnPlayerSkin";
+    public static final String WHITE_PAWN_SKIN = "lightAndShadowResources:whitePawnPlayerSkin";
     public static final String WHITE_HEALTH_ICON = "lightAndShadowResources:icons#circle";
     public static final String RED_HEALTH_ICON = "engine:icons#redHeart";
     public static final String BLACK_HEALTH_ICON = "lightAndShadowResources:icons#spades";

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -23,8 +25,10 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
+import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivateComponent;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
 import org.terasology.logic.characters.VisualCharacterComponent;
+import org.terasology.logic.common.ActivateEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.logic.SkeletalMeshComponent;
 import org.terasology.utilities.Assets;
@@ -36,10 +40,16 @@ public class ClientSkinSystem extends BaseComponentSystem {
     @In
     private AssetManager assetManager;
 
-    @ReceiveEvent
-    public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
-        EntityRef player = event.player;
-        String team = event.team;
+    private static final Logger logger = LoggerFactory.getLogger(ClientSkinSystem.class);
+
+    @ReceiveEvent(components = {SetTeamOnActivateComponent.class})
+    public void onActivate(ActivateEvent event, EntityRef entity) {
+        EntityRef player = event.getInstigator();
+        String team = LASUtils.BLACK_TEAM;
+        handlePlayerTeleport(player, team);
+    }
+
+    private void handlePlayerTeleport(EntityRef player, String team) {
         if (player.hasComponent(VisualCharacterComponent.class)) {
             VisualCharacterComponent visualCharacterComponent = player.getComponent(VisualCharacterComponent.class);
             if (visualCharacterComponent.visualCharacter != EntityRef.NULL && visualCharacterComponent.visualCharacter.hasComponent(SkeletalMeshComponent.class)) {
@@ -52,4 +62,20 @@ public class ClientSkinSystem extends BaseComponentSystem {
             }
         }
     }
+
+    //@ReceiveEvent
+    //public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
+//        String team = event.team;
+//        if (entity.hasComponent(VisualCharacterComponent.class)) {
+//            VisualCharacterComponent visualCharacterComponent = entity.getComponent(VisualCharacterComponent.class);
+//            if (visualCharacterComponent.visualCharacter != EntityRef.NULL && visualCharacterComponent.visualCharacter.hasComponent(SkeletalMeshComponent.class)) {
+//                SkeletalMeshComponent skeletalMeshComponent = visualCharacterComponent.visualCharacter.getComponent(SkeletalMeshComponent.class);
+//                if (team.equals(LASUtils.BLACK_TEAM)) {
+//                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.BLACK_PAWN_SKIN).get();
+//                } else if (team.equals(LASUtils.RED_TEAM)) {
+//                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.RED_PAWN_SKIN).get();
+//                }
+//            }
+//        }
+//    }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
-import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -24,29 +24,32 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
-import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.characters.VisualCharacterComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.logic.SkeletalMeshComponent;
+import org.terasology.utilities.Assets;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientSkinSystem extends BaseComponentSystem {
     @In
     private EntityManager entityManager;
-
-    private EntityBuilder builder;
+    @In
+    private AssetManager assetManager;
 
     @ReceiveEvent
     public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
         EntityRef player = event.player;
         String team = event.team;
-        if (team.equals(LASUtils.BLACK_TEAM)) {
-            builder = entityManager.newBuilder(LASUtils.BLACK_PAWN);
-            builder.saveComponent(player.getComponent(LocationComponent.class));
-            builder.build();
-        }
-        if (team.equals(LASUtils.RED_TEAM)) {
-            builder = entityManager.newBuilder(LASUtils.RED_PAWN);
-            builder.saveComponent(player.getComponent(LocationComponent.class));
-            builder.build();
+        if (player.hasComponent(VisualCharacterComponent.class)) {
+            VisualCharacterComponent visualCharacterComponent = player.getComponent(VisualCharacterComponent.class);
+            if (visualCharacterComponent.visualCharacter != EntityRef.NULL && visualCharacterComponent.visualCharacter.hasComponent(SkeletalMeshComponent.class)) {
+                SkeletalMeshComponent skeletalMeshComponent = visualCharacterComponent.visualCharacter.getComponent(SkeletalMeshComponent.class);
+                if (team.equals(LASUtils.BLACK_TEAM)) {
+                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.BLACK_PAWN_SKIN).get();
+                } else if (team.equals(LASUtils.RED_TEAM)) {
+                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.RED_PAWN_SKIN).get();
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -29,10 +29,13 @@ import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent
 import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivateComponent;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
+import org.terasology.logic.characters.VisualCharacterComponent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.logic.SkeletalMeshComponent;
+import org.terasology.utilities.Assets;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class TeleporterSystem extends BaseComponentSystem {
@@ -67,7 +70,19 @@ public class TeleporterSystem extends BaseComponentSystem {
     }
 
     private void setPlayerSkin(EntityRef player, String team) {
-        sendEventToClients(new AddPlayerSkinToPlayerEvent(player, team));
+//        if (player.hasComponent(VisualCharacterComponent.class)) {
+//            VisualCharacterComponent visualCharacterComponent = player.getComponent(VisualCharacterComponent.class);
+//            if (visualCharacterComponent.visualCharacter != EntityRef.NULL && visualCharacterComponent.visualCharacter.hasComponent(SkeletalMeshComponent.class)) {
+//                SkeletalMeshComponent skeletalMeshComponent = visualCharacterComponent.visualCharacter.getComponent(SkeletalMeshComponent.class);
+//                if (team.equals(LASUtils.BLACK_TEAM)) {
+//                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.BLACK_PAWN_SKIN).get();
+//                } else if (team.equals(LASUtils.RED_TEAM)) {
+//                    skeletalMeshComponent.material = Assets.getMaterial(LASUtils.RED_PAWN_SKIN).get();
+//                }
+//            }
+//        }
+        //sendEventToClients(new AddPlayerSkinToPlayerEvent(player, team));
+        player.send(new AddPlayerSkinToPlayerEvent(player, team));
     }
 
     private void sendEventToClients(Event event) {


### PR DESCRIPTION
This changes the way player skinning is handled by swapping out the material of the default player character when the player picks a team. This gets rid of problems with the player model being visible on team pick and remaining behind when player disconnects. 

This is still a WIP because of a a bug with player skinning where picking a team will change the skins of all the players, not just the player activating the teleporter.