### PR TITLE
[WIP] HUD now reskins with red hearts/black spades on team selection 

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -17,14 +17,13 @@ package org.terasology.ligthandshadow.componentsystem;
 
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.registry.In;
-import org.terasology.world.block.BlockManager;
 
 public final class LASUtils {
     public static final String BLACK_FLAG_URI = "lightAndShadowResources:blackFlag";
     public static final String RED_FLAG_URI = "lightAndShadowResources:redFlag";
     public static final String RED_TEAM = "red";
     public static final String BLACK_TEAM = "black";
+    public static final String WHITE_TEAM = "white";
     /**
      * Position of Red base
      */
@@ -95,6 +94,33 @@ public final class LASUtils {
         }
         if (team.equals(BLACK_TEAM)) {
             return BLACK_TELEPORT_DESTINATION;
+        }
+        return null;
+    }
+
+
+    public static String getHealthIcon (String team) {
+        if (team.equals(RED_TEAM)) {
+            return RED_HEALTH_ICON;
+        }
+        if (team.equals(BLACK_TEAM)) {
+            return BLACK_HEALTH_ICON;
+        }
+        if (team.equals(WHITE_TEAM)) {
+            return WHITE_HEALTH_ICON;
+        }
+        return null;
+    }
+
+    public static String getHealthSkin (String team) {
+        if (team.equals(RED_TEAM)) {
+            return RED_HEALTH_SKIN;
+        }
+        if (team.equals(BLACK_TEAM)) {
+            return BLACK_HEALTH_SKIN;
+        }
+        if (team.equals(WHITE_TEAM)) {
+            return WHITE_HEALTH_SKIN;
         }
         return null;
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -24,15 +24,29 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
+import org.terasology.ligthandshadow.componentsystem.events.SetPlayerHealthHUDEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.hud.HealthHud;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+import org.terasology.utilities.Assets;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientSkinSystem extends BaseComponentSystem {
     @In
     private EntityManager entityManager;
+    @In
+    private NUIManager nuiManager;
 
     private EntityBuilder builder;
+
+    @Override
+    public void initialise() {
+        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(LASUtils.WHITE_TEAM)).get());
+        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(LASUtils.WHITE_TEAM)).get());
+    }
 
     @ReceiveEvent
     public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
@@ -48,5 +62,13 @@ public class ClientSkinSystem extends BaseComponentSystem {
             builder.saveComponent(player.getComponent(LocationComponent.class));
             builder.build();
         }
+    }
+
+    @ReceiveEvent
+    public void onSetPlayerHealthHUDEvent(SetPlayerHealthHUDEvent event, EntityRef entity) {
+        String team = event.team;
+        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(team)).get());
+        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(team)).get());
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/LASSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/LASSystem.java
@@ -20,11 +20,17 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.ligthandshadow.componentsystem.LASUtils;
+import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.action.RemoveItemAction;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.hud.HealthHud;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.items.BlockItemFactory;
@@ -39,6 +45,8 @@ public class LASSystem extends BaseComponentSystem {
     private WorldProvider worldProvider;
     @In
     private BlockManager blockManager;
+    @In
+    private NUIManager nuiManager;
 
     /**
      * Gives player inventory items on game start
@@ -54,6 +62,9 @@ public class LASSystem extends BaseComponentSystem {
 
     @Override
     public void initialise() {
+        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(LASUtils.WHITE_TEAM)).get());
+        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(LASUtils.WHITE_TEAM)).get());
     }
 
     @Override

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -31,6 +31,7 @@ import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent
 import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivateComponent;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
 import org.terasology.ligthandshadow.componentsystem.events.ScoreUpdateFromServerEvent;
+import org.terasology.ligthandshadow.componentsystem.events.SetPlayerHealthHUDEvent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
@@ -38,6 +39,10 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.hud.HealthHud;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+import org.terasology.utilities.Assets;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 
@@ -48,6 +53,8 @@ public class TeleporterSystem extends BaseComponentSystem {
     InventoryManager inventoryManager;
     @In
     EntityManager entityManager;
+    @In
+    private NUIManager nuiManager;
 
     private EntityBuilder builder;
 
@@ -76,10 +83,16 @@ public class TeleporterSystem extends BaseComponentSystem {
         player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
         inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(MAGIC_STAFF_URI));
         setPlayerSkin(player, team);
+        setPlayerHud(player, team);
     }
+
 
     private void setPlayerSkin(EntityRef player, String team) {
         sendEventToClients(new AddPlayerSkinToPlayerEvent(player, team));
+    }
+
+    private void setPlayerHud(EntityRef player, String team) {
+        sendEventToClients(new SetPlayerHealthHUDEvent(player, team));
     }
 
     private void sendEventToClients(Event event) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.BroadcastEvent;
+
+@BroadcastEvent
+public class SetPlayerHealthHUDEvent implements Event {
+    public EntityRef player;
+    public String team;
+    public EntityRef client;
+
+    public SetPlayerHealthHUDEvent() {
+    }
+
+    public SetPlayerHealthHUDEvent(EntityRef player, String team) {
+        this.player = player;
+        this.team = team;
+    }
+}


### PR DESCRIPTION
Player health HUD now changes symbols based on the team players pick. Default is rounded circles (white), with the symbols of the health HUD changing to black spades and/or red hearts on team selection.

This is a work in progress because of a bug causing the change in NUIManager to change the HUD across all players rather than just the player making a team selection. 