### PR TITLE
Health HUD reskinning based on team

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -23,6 +23,7 @@ public final class LASUtils {
     public static final String RED_FLAG_URI = "lightAndShadowResources:redFlag";
     public static final String RED_TEAM = "red";
     public static final String BLACK_TEAM = "black";
+    public static final String WHITE_TEAM = "white";
     /**
      * Position of Red base
      */
@@ -96,6 +97,32 @@ public final class LASUtils {
         }
         if (team.equals(BLACK_TEAM)) {
             return BLACK_TELEPORT_DESTINATION;
+        }
+        return null;
+    }
+
+    public static String getHealthIcon (String team) {
+        if (team.equals(RED_TEAM)) {
+            return RED_HEALTH_ICON;
+        }
+        if (team.equals(BLACK_TEAM)) {
+            return BLACK_HEALTH_ICON;
+        }
+        if (team.equals(WHITE_TEAM)) {
+            return WHITE_HEALTH_ICON;
+        }
+        return null;
+    }
+
+    public static String getHealthSkin (String team) {
+        if (team.equals(RED_TEAM)) {
+            return RED_HEALTH_SKIN;
+        }
+        if (team.equals(BLACK_TEAM)) {
+            return BLACK_HEALTH_SKIN;
+        }
+        if (team.equals(WHITE_TEAM)) {
+            return WHITE_HEALTH_SKIN;
         }
         return null;
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -24,15 +24,29 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
+import org.terasology.ligthandshadow.componentsystem.events.SetPlayerHealthHUDEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.hud.HealthHud;
+import org.terasology.rendering.nui.widgets.UIIconBar;
+import org.terasology.utilities.Assets;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientSkinSystem extends BaseComponentSystem {
     @In
     private EntityManager entityManager;
+    @In
+    private NUIManager nuiManager;
 
     private EntityBuilder builder;
+
+    @Override
+    public void initialise() {
+        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(LASUtils.WHITE_TEAM)).get());
+        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(LASUtils.WHITE_TEAM)).get());
+    }
 
     @ReceiveEvent
     public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
@@ -48,5 +62,12 @@ public class ClientSkinSystem extends BaseComponentSystem {
             builder.saveComponent(player.getComponent(LocationComponent.class));
             builder.build();
         }
+    }
+    @ReceiveEvent
+    public void onSetPlayerHealthHUDEvent(SetPlayerHealthHUDEvent event, EntityRef entity) {
+        String team = event.team;
+        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(team)).get());
+        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(team)).get());
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -33,6 +33,9 @@ import org.terasology.rendering.nui.layers.hud.HealthHud;
 import org.terasology.rendering.nui.widgets.UIIconBar;
 import org.terasology.utilities.Assets;
 
+/**
+ * Handles changing players' health HUD and skin based on their teams.
+ */
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientSkinSystem extends BaseComponentSystem {
     @In
@@ -51,6 +54,12 @@ public class ClientSkinSystem extends BaseComponentSystem {
         healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(LASUtils.WHITE_TEAM)).get());
     }
 
+    /**
+     * Changes player skin on receiving the corresponding event.
+     *
+     * @param event
+     * @param entity
+     */
     @ReceiveEvent
     public void onAddPlayerSkinToPlayer(AddPlayerSkinToPlayerEvent event, EntityRef entity) {
         EntityRef player = event.player;
@@ -66,6 +75,13 @@ public class ClientSkinSystem extends BaseComponentSystem {
             builder.build();
         }
     }
+
+    /**
+     * Changes player health hud on receiving the corresponding event.
+     *
+     * @param event
+     * @param entity
+     */
     @ReceiveEvent
     public void onSetPlayerHealthHUDEvent(SetPlayerHealthHUDEvent event, EntityRef entity) {
         EntityRef player = event.player;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientSkinSystem.java
@@ -26,6 +26,7 @@ import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
 import org.terasology.ligthandshadow.componentsystem.events.SetPlayerHealthHUDEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layers.hud.HealthHud;
@@ -38,6 +39,8 @@ public class ClientSkinSystem extends BaseComponentSystem {
     private EntityManager entityManager;
     @In
     private NUIManager nuiManager;
+    @In
+    private LocalPlayer localPlayer;
 
     private EntityBuilder builder;
 
@@ -65,9 +68,13 @@ public class ClientSkinSystem extends BaseComponentSystem {
     }
     @ReceiveEvent
     public void onSetPlayerHealthHUDEvent(SetPlayerHealthHUDEvent event, EntityRef entity) {
+        EntityRef player = event.player;
         String team = event.team;
-        HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
-        healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(team)).get());
-        healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(team)).get());
+
+        if (player.getId() == localPlayer.getCharacterEntity().getId()) {
+            HealthHud healthHud = nuiManager.getHUD().getHUDElement("core:healthHud", HealthHud.class);
+            healthHud.find("healthBar", UIIconBar.class).setIcon(Assets.getTextureRegion(LASUtils.getHealthIcon(team)).get());
+            healthHud.setSkin(Assets.getSkin(LASUtils.getHealthSkin(team)).get());
+        }
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -35,6 +35,12 @@ import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 
+/**
+ * Teleports players to play arena once they chose their team.
+ * It also sends events to change players skins and hud based on team they have chosen.
+ *
+ * @see ClientSkinSystem
+ */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class TeleporterSystem extends BaseComponentSystem {
     private static final Logger logger = LoggerFactory.getLogger(TeleporterSystem.class);
@@ -44,8 +50,13 @@ public class TeleporterSystem extends BaseComponentSystem {
     @In
     EntityManager entityManager;
 
-    /* Depending on which teleporter the player chooses, they are set to that team
-     * and teleported to that base */
+    /**
+     * Depending on which teleporter the player chooses, they are set to that team
+     * and teleported to that base
+     *
+     * @param event
+     * @param entity
+     */
     @ReceiveEvent(components = {SetTeamOnActivateComponent.class})
     public void onActivate(ActivateEvent event, EntityRef entity) {
         EntityRef player = event.getInstigator();

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -28,6 +28,7 @@ import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivateComponent;
 import org.terasology.ligthandshadow.componentsystem.events.AddPlayerSkinToPlayerEvent;
+import org.terasology.ligthandshadow.componentsystem.events.SetPlayerHealthHUDEvent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
@@ -64,10 +65,15 @@ public class TeleporterSystem extends BaseComponentSystem {
         player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
         inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(LASUtils.MAGIC_STAFF_URI));
         setPlayerSkin(player, team);
+        setPlayerHud(player, team);
     }
 
     private void setPlayerSkin(EntityRef player, String team) {
         sendEventToClients(new AddPlayerSkinToPlayerEvent(player, team));
+    }
+
+    private void setPlayerHud(EntityRef player, String team) {
+        sendEventToClients(new SetPlayerHealthHUDEvent(player, team));
     }
 
     private void sendEventToClients(Event event) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
@@ -17,7 +17,9 @@ package org.terasology.ligthandshadow.componentsystem.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.network.BroadcastEvent;
 
+@BroadcastEvent
 public class SetPlayerHealthHUDEvent implements Event {
     public EntityRef player;
     public String team;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
@@ -19,6 +19,9 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.network.BroadcastEvent;
 
+/**
+ * Event to change player health HUD.
+ */
 @BroadcastEvent
 public class SetPlayerHealthHUDEvent implements Event {
     public EntityRef player;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/SetPlayerHealthHUDEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+public class SetPlayerHealthHUDEvent implements Event {
+    public EntityRef player;
+    public String team;
+
+    public SetPlayerHealthHUDEvent() {
+    }
+
+    public SetPlayerHealthHUDEvent(EntityRef player, String team) {
+        this.player = player;
+        this.team = team;
+    }
+}


### PR DESCRIPTION
Solves [#73](https://github.com/Terasology/LightAndShadow/pull/73)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players

Health HUD should be initially white dots and it should change to Spades for black team, hearts for red team.