### PR TITLE
Respawn and heal player on death

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -39,10 +39,10 @@ public class PlayerDeathSystem extends BaseComponentSystem {
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void beforeDestroy(BeforeDestroyEvent event, EntityRef player, CharacterComponent characterComponent, AliveCharacterComponent aliveCharacterComponent) {
         if (player.hasComponent(PlayerCharacterComponent.class)) {
-            // Consume the BeforeDestroyEvent so that the DoDestroy event is never sent for player entities
             event.consume();
             logger.info(player.toFullDescription());
             String team = player.getComponent(LASTeamComponent.class).team;
+            player.send(new DoHealEvent(100000, player));
             player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.ligthandshadow.componentsystem.LASUtils;
+import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
+import org.terasology.logic.characters.AliveCharacterComponent;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.characters.CharacterTeleportEvent;
+import org.terasology.logic.health.BeforeDestroyEvent;
+import org.terasology.logic.health.DoHealEvent;
+import org.terasology.logic.players.PlayerCharacterComponent;
+
+
+@RegisterSystem
+public class PlayerDeathSystem extends BaseComponentSystem {
+    Logger logger = LoggerFactory.getLogger(PlayerDeathSystem.class);
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void beforeDestroy(BeforeDestroyEvent event, EntityRef player, CharacterComponent characterComponent, AliveCharacterComponent aliveCharacterComponent) {
+        if (player.hasComponent(PlayerCharacterComponent.class)) {
+            // Consume the BeforeDestroyEvent so that the DoDestroy event is never sent for player entities
+            event.consume();
+            logger.info(player.toFullDescription());
+            String team = player.getComponent(LASTeamComponent.class).team;
+            player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
+        }
+    }
+}

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -40,7 +40,6 @@ public class PlayerDeathSystem extends BaseComponentSystem {
     public void beforeDestroy(BeforeDestroyEvent event, EntityRef player, CharacterComponent characterComponent, AliveCharacterComponent aliveCharacterComponent) {
         if (player.hasComponent(PlayerCharacterComponent.class)) {
             event.consume();
-            logger.info(player.toFullDescription());
             String team = player.getComponent(LASTeamComponent.class).team;
             player.send(new DoHealEvent(100000, player));
             player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));


### PR DESCRIPTION
**Project Card**:
[Handle respawn on death](https://github.com/orgs/Terasology/projects/17#card-21937677)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players
4. Kill one of the players by repeatedly attacking it through another one.

**Expected outcome**:
The killed player should get respawned at its home base with full health restored.