### PR TITLE
Handle inventory on death

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
@@ -31,23 +29,18 @@ import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.health.BeforeDestroyEvent;
 import org.terasology.logic.health.DoHealEvent;
-import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
+import org.terasology.logic.inventory.events.DropItemRequest;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.PlayerCharacterComponent;
-import org.terasology.math.geom.Vector3i;
+import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.items.BlockItemComponent;
-
-import java.util.List;
 
 
 @RegisterSystem
 public class PlayerDeathSystem extends BaseComponentSystem {
-    Logger logger = LoggerFactory.getLogger(PlayerDeathSystem.class);
-
     @In
     private AssetManager assetManager;
 
@@ -65,23 +58,18 @@ public class PlayerDeathSystem extends BaseComponentSystem {
         if (player.hasComponent(PlayerCharacterComponent.class)) {
             event.consume();
             String team = player.getComponent(LASTeamComponent.class).team;
-            List<EntityRef> itemsSlots = player.getComponent(InventoryComponent.class).itemSlots;
 
             Prefab staffPrefab = assetManager.getAsset(LASUtils.MAGIC_STAFF_URI, Prefab.class).orElse(null);
 
-            for (EntityRef slot : itemsSlots) {
+            Vector3f startPosition = new Vector3f(player.getComponent(LocationComponent.class).getLocalPosition());
+            Vector3f impulse = Vector3f.zero();
+            int inventorySize = inventoryManager.getNumSlots(player);
+            for (int slotNumber = 0; slotNumber <= inventorySize; slotNumber++) {
+                EntityRef slot = inventoryManager.getItemInSlot(player, slotNumber);
                 Prefab currentPrefab = slot.getParentPrefab();
                 if (currentPrefab != null && !currentPrefab.equals(staffPrefab)) {
-                    if (slot.hasComponent(BlockItemComponent.class) &&
-                            (slot.getComponent(BlockItemComponent.class).blockFamily.getURI().toString().equals(LASUtils.BLACK_FLAG_URI) ||
-                                    slot.getComponent(BlockItemComponent.class).blockFamily.getURI().toString().equals(LASUtils.RED_FLAG_URI) )) {
-                        if(team.equals(LASUtils.BLACK_TEAM)) {
-                            worldProvider.setBlock(LASUtils.getFlagLocation(LASUtils.RED_TEAM), blockManager.getBlock(LASUtils.getFlagURI(LASUtils.RED_TEAM)));
-                        } else {
-                            worldProvider.setBlock(LASUtils.getFlagLocation(LASUtils.BLACK_TEAM), blockManager.getBlock(LASUtils.getFlagURI(LASUtils.BLACK_TEAM)));
-                        }
-                    }
-                    inventoryManager.removeItem(player, EntityRef.NULL, slot, true);
+                    int count = inventoryManager.getStackSize(slot);
+                    player.send(new DropItemRequest(slot, player, impulse, startPosition, count));
                 }
             }
 


### PR DESCRIPTION
**Project Card**:
[Handle respawn on death](https://github.com/orgs/Terasology/projects/17#card-21937677)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players
4. Give "player one" items and blocks through cheat "give item"
5. Collect opposition flag using 'player one'.
4. Kill "player one" by repeatedly attacking it through "player two".
5. Try to collect dropped items and flag using "player two".

**Expected outcome**:
The killed player should get respawned at its home base with full health restored. All the items held by them should get dropped at the same location except the magic staff. Trying to collect the dropped flag sends it directly to home base.