### PR TITLE
Destroy dropped items on death after a delay

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -59,6 +59,9 @@ public final class LASUtils {
     public static final String DEATH_SCREEN = "engine:DeathScreen";
     public static final String ONLINE_PLAYERS_OVERLAY = "engine:onlinePlayersOverlay";
 
+    public static final String DROPPED_ITEM_ON_DEATH = "dropped_item_indicator";
+    public static final long DROPPED_ITEM_DELAY = 20000;
+
     private LASUtils() {
     }
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/DroppedItemComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/DroppedItemComponent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.components;
+
+import org.terasology.entitySystem.Component;
+
+/**
+ * Indicates a dropped item from inventory when the player dies.
+ * It is removed when a player picks it up again.
+ *
+ * @see org.terasology.ligthandshadow.componentsystem.controllers.PlayerDeathSystem
+ */
+public class DroppedItemComponent implements Component {
+}

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -35,6 +35,7 @@ import org.terasology.logic.health.BeforeDestroyEvent;
 import org.terasology.logic.health.DoHealEvent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.events.DropItemRequest;
+import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.PlayerCharacterComponent;
 import org.terasology.math.geom.Vector3f;
@@ -114,6 +115,24 @@ public class PlayerDeathSystem extends BaseComponentSystem {
                 }
             }
             entity.destroy();
+        }
+    }
+
+    /**
+     * Remove dropped item component and delay action on picking up the item.
+     * When an item is picked up, its inventory slot changes, and hence we can use this event.
+     *
+     * @param event  The event which indicates that item is picked up
+     * @param entity the character entity that picks up the item
+     */
+    @ReceiveEvent(components = {LASTeamComponent.class})
+    public void onInventorySlotChanged(InventorySlotChangedEvent event, EntityRef entity) {
+        EntityRef item = event.getNewItem();
+        if (item.hasComponent(DroppedItemComponent.class)) {
+            item.removeComponent(DroppedItemComponent.class);
+        }
+        if (delayManager.hasDelayedAction(item, LASUtils.DROPPED_ITEM_ON_DEATH)) {
+            delayManager.cancelDelayedAction(item, LASUtils.DROPPED_ITEM_ON_DEATH);
         }
     }
 


### PR DESCRIPTION
**Project Cards**:
1. [Handle Player Death [3]](https://github.com/orgs/Terasology/projects/17#card-22550695)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players
4. Give some blocks and prefab items to player 1.
5. Capture the flag with player 1.
6. Kill player 1 with player 2.
7. Collect some dropped items with player 2.
8. Repeat step 4 to 7 by exchanging player 1 and 2.

**Expected outcome**:
Items not collected will get destroyed. If it is flag, it will get teleported back to the base. If you collect the item, delay will be removed and it will not be destroyed.