### PR TITLE
Game Restart Implementation

### DIFF
--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -39,6 +39,30 @@
                         "type": "UIButton",
                         "text": "${engine:menu#exit-game}",
                         "id": "exitGame"
+                    },
+                    {
+                     "type": "UILabel",
+                     "id": "deathDetails",
+                     "visible": false,
+                     "layoutInfo": {
+                       "use-content-height": false,
+                       "use-content-width": false,
+                       "position-top": {},
+                       "position-left": {}
+                     }
+                    },
+                    {
+                     "type": "UIButton",
+                     "text": "${engine:menu#respawn}",
+                     "id": "respawn",
+                     "enabled": false,
+                     "visible": false,
+                     "layoutInfo": {
+                       "use-content-height": false,
+                       "use-content-width": false,
+                       "position-top": {},
+                       "position-left": {}
+                     }
                     }
                 ],
                 "layoutInfo": {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -36,7 +36,6 @@ import org.terasology.rendering.nui.widgets.UILabel;
  */
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientGameOverSystem extends BaseComponentSystem {
-
     @In
     private NUIManager nuiManager;
     @In
@@ -44,15 +43,17 @@ public class ClientGameOverSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onGameOver(GameOverEvent event, EntityRef entity) {
-        nuiManager.removeOverlay(LASUtils.ONLINE_PLAYERS_OVERLAY);
-        DeathScreen deathScreen = nuiManager.pushScreen(LASUtils.DEATH_SCREEN, DeathScreen.class);
-        UILabel gameOverDetails = deathScreen.find("gameOverDetails", UILabel.class);
-        WidgetUtil.trySubscribe(deathScreen, "restart", widget -> triggerRestart());
-        if (gameOverDetails != null) {
-            if (event.winningTeam.equals(localPlayer.getCharacterEntity().getComponent(LASTeamComponent.class).team)) {
-                gameOverDetails.setText("You Win!");
-            } else {
-                gameOverDetails.setText("You Lose!");
+        if (localPlayer.getClientEntity().equals(entity)) {
+            nuiManager.removeOverlay(LASUtils.ONLINE_PLAYERS_OVERLAY);
+            DeathScreen deathScreen = nuiManager.pushScreen(LASUtils.DEATH_SCREEN, DeathScreen.class);
+            UILabel gameOverDetails = deathScreen.find("gameOverDetails", UILabel.class);
+            WidgetUtil.trySubscribe(deathScreen, "restart", widget -> triggerRestart());
+            if (gameOverDetails != null) {
+                if (event.winningTeam.equals(localPlayer.getCharacterEntity().getComponent(LASTeamComponent.class).team)) {
+                    gameOverDetails.setText("You Win!");
+                } else {
+                    gameOverDetails.setText("You Lose!");
+                }
             }
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -23,9 +23,11 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.events.GameOverEvent;
+import org.terasology.ligthandshadow.componentsystem.events.RestartRequestEvent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.layers.ingame.DeathScreen;
 import org.terasology.rendering.nui.widgets.UILabel;
 
@@ -45,6 +47,7 @@ public class ClientGameOverSystem extends BaseComponentSystem {
         nuiManager.removeOverlay(LASUtils.ONLINE_PLAYERS_OVERLAY);
         DeathScreen deathScreen = nuiManager.pushScreen(LASUtils.DEATH_SCREEN, DeathScreen.class);
         UILabel gameOverDetails = deathScreen.find("gameOverDetails", UILabel.class);
+        WidgetUtil.trySubscribe(deathScreen, "restart", widget -> triggerRestart());
         if (gameOverDetails != null) {
             if (event.winningTeam.equals(localPlayer.getCharacterEntity().getComponent(LASTeamComponent.class).team)) {
                 gameOverDetails.setText("You Win!");
@@ -52,5 +55,9 @@ public class ClientGameOverSystem extends BaseComponentSystem {
                 gameOverDetails.setText("You Lose!");
             }
         }
+    }
+
+    private void triggerRestart() {
+        localPlayer.getClientEntity().send(new RestartRequestEvent());
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -41,6 +41,12 @@ public class ClientGameOverSystem extends BaseComponentSystem {
     @In
     private LocalPlayer localPlayer;
 
+    /**
+     * System to show game over screen once a team achieves goal score.
+     *
+     * @param event  the event
+     * @param entity the entity
+     */
     @ReceiveEvent
     public void onGameOver(GameOverEvent event, EntityRef entity) {
         if (localPlayer.getClientEntity().equals(entity)) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
@@ -41,6 +41,13 @@ public class RestartSystem extends BaseComponentSystem {
     @In
     NUIManager nuiManager;
 
+    /**
+     * System to invoke restart. Only the host can restart the game.
+     * All players' health are restored and they are transported back to their bases.
+     *
+     * @param event
+     * @param clientEntity
+     */
     @ReceiveEvent(netFilter = RegisterMode.AUTHORITY)
     public void onRestartRequest(RestartRequestEvent event, EntityRef clientEntity) {
         if (localPlayer.getClientEntity().equals(clientEntity)) {
@@ -50,13 +57,23 @@ public class RestartSystem extends BaseComponentSystem {
                 String team = player.getComponent(LASTeamComponent.class).team;
                 player.send(new DoHealEvent(100000, player));
                 player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
-                player.send(new ClientRestartEvent());
+                client.send(new ClientRestartEvent());
             }
         }
     }
 
+    /**
+     * System to close game over screen once restart is complete.
+     *
+     * @param event
+     * @param clientEntity
+     */
     @ReceiveEvent(netFilter = RegisterMode.CLIENT)
-    public void onClientRestart(ClientRestartEvent event, EntityRef entity) {
-        nuiManager.closeScreen(LASUtils.DEATH_SCREEN);
+    public void onClientRestart(ClientRestartEvent event, EntityRef clientEntity) {
+        if (localPlayer.getClientEntity().equals(clientEntity)) {
+            if (nuiManager.isOpen(LASUtils.DEATH_SCREEN)) {
+                nuiManager.closeScreen(LASUtils.DEATH_SCREEN);
+            }
+        }
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.controllers;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.ligthandshadow.componentsystem.LASUtils;
+import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
+import org.terasology.ligthandshadow.componentsystem.events.ClientRestartEvent;
+import org.terasology.ligthandshadow.componentsystem.events.RestartRequestEvent;
+import org.terasology.logic.characters.CharacterTeleportEvent;
+import org.terasology.logic.health.DoHealEvent;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.network.ClientComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+
+@RegisterSystem
+public class RestartSystem extends BaseComponentSystem {
+    @In
+    LocalPlayer localPlayer;
+    @In
+    EntityManager entityManager;
+    @In
+    NUIManager nuiManager;
+
+    @ReceiveEvent(netFilter = RegisterMode.AUTHORITY)
+    public void onRestartRequest(RestartRequestEvent event, EntityRef clientEntity) {
+        if (localPlayer.getClientEntity().equals(clientEntity)) {
+            Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
+            for (EntityRef client: clients) {
+                EntityRef player = client.getComponent(ClientComponent.class).character;
+                String team = player.getComponent(LASTeamComponent.class).team;
+                player.send(new DoHealEvent(100000, player));
+                player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
+                player.send(new ClientRestartEvent());
+            }
+        }
+    }
+
+    @ReceiveEvent(netFilter = RegisterMode.CLIENT)
+    public void onClientRestart(ClientRestartEvent event, EntityRef entity) {
+        nuiManager.closeScreen(LASUtils.DEATH_SCREEN);
+    }
+}

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
@@ -28,10 +28,15 @@ import org.terasology.ligthandshadow.componentsystem.components.HasFlagComponent
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.components.RedFlagComponent;
 import org.terasology.ligthandshadow.componentsystem.components.WinConditionCheckOnActivateComponent;
+import org.terasology.ligthandshadow.componentsystem.events.ClientRestartEvent;
 import org.terasology.ligthandshadow.componentsystem.events.GameOverEvent;
+import org.terasology.ligthandshadow.componentsystem.events.RestartRequestEvent;
 import org.terasology.ligthandshadow.componentsystem.events.ScoreUpdateFromServerEvent;
+import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
+import org.terasology.logic.health.DoHealEvent;
 import org.terasology.logic.inventory.InventoryManager;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
@@ -58,6 +63,8 @@ public class ScoreSystem extends BaseComponentSystem {
     private BlockManager blockManager;
     @In
     private WorldProvider worldProvider;
+    @In
+    private LocalPlayer localPlayer;
 
     private int redScore;
     private int blackScore;
@@ -93,6 +100,16 @@ public class ScoreSystem extends BaseComponentSystem {
     @ReceiveEvent(components = {WinConditionCheckOnActivateComponent.class, LASTeamComponent.class})
     public void onActivate(ActivateEvent event, EntityRef entity) {
         checkAndResetGameOnScore(event, entity);
+    }
+
+    @ReceiveEvent
+    public void onRestartRequest(RestartRequestEvent event, EntityRef clientEntity) {
+        if (localPlayer.getClientEntity().equals(clientEntity)) {
+            redScore = 0;
+            blackScore = 0;
+            sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.RED_TEAM, redScore));
+            sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.BLACK_TEAM, blackScore));
+        }
     }
 
     private void checkAndResetGameOnScore(ActivateEvent event, EntityRef entity) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/ClientRestartEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/ClientRestartEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.OwnerEvent;
+
+/**
+ * Event to indicate a client that restart is complete.
+ */
+@OwnerEvent
+public class ClientRestartEvent implements Event {
+}

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
@@ -19,6 +19,9 @@ import org.terasology.entitySystem.event.Event;
 import org.terasology.network.BroadcastEvent;
 import org.terasology.network.OwnerEvent;
 
+/**
+ * Event to indicate clients about GameOver.
+ */
 @OwnerEvent
 public class GameOverEvent implements Event {
     public String winningTeam;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
@@ -17,8 +17,9 @@ package org.terasology.ligthandshadow.componentsystem.events;
 
 import org.terasology.entitySystem.event.Event;
 import org.terasology.network.BroadcastEvent;
+import org.terasology.network.OwnerEvent;
 
-@BroadcastEvent
+@OwnerEvent
 public class GameOverEvent implements Event {
     public String winningTeam;
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/RestartRequestEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/RestartRequestEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.ServerEvent;
+
+/**
+ * Event to request game restart by a client.
+ */
+@ServerEvent
+public class RestartRequestEvent implements Event {
+}


### PR DESCRIPTION
**Project Cards**:
1. [Game Restart [1]](https://github.com/orgs/Terasology/projects/17#card-21938486)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players
4. The player to collect the flag 5 times first wins!
5. Press the restart button, first from the remote clients and then from the server/client instance.

**Expected outcome**:
The game over screen should now show a list of all players. Pressing restart will get players back to their bases and reset the points and health. Remote clients shouldn't be able to restart the game. Only Server/Client instance should be able to restart the game.