### PR TITLE
Player Statistics Implementation

### DIFF
--- a/deltas/engine/prefabs/player/player.prefab
+++ b/deltas/engine/prefabs/player/player.prefab
@@ -2,5 +2,6 @@
     "LASTeam" : {
         "team" : "white"
     },
-    "FlagDropOnActivate" : {}
+    "FlagDropOnActivate" : {},
+    "PlayerStatistics" : {}
 }

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -21,6 +21,40 @@
                         "size": [1, 16]
                     },
                     {
+                        "type": "migLayout",
+                        "id": "playerStatistics",
+                        "rowConstraints": "0",
+                        "colConstraints": "0",
+                        "contents": [
+                            {
+                                "type": "UILabel",
+                                "text": "Player",
+                                "layoutInfo": {
+                                    "cc": ""
+                                }
+                            },
+                            {
+                                "type": "UILabel",
+                                "text": "Kills",
+                                "layoutInfo": {
+                                    "cc": ""
+                                }
+                            },
+                            {
+                                "type": "UILabel",
+                                "text": "Deaths",
+                                "layoutInfo": {
+                                    "cc": "wrap"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "UISpace",
+                        "size": [1, 16]
+                    },
+
+                    {
                          "type": "UIButton",
                          "text": "Restart",
                          "id": "restart"

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.ligthandshadow.componentsystem.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.network.Replicate;
+
+/**
+ * Component to store a players game statistics.
+ * It currently stores deaths and kills.
+ *
+ */
+public class PlayerStatisticsComponent implements Component {
+    @Replicate
+    public int kills;
+
+    @Replicate
+    public int deaths;
+
+    public  PlayerStatisticsComponent() {
+        this.kills = 0;
+        this.deaths = 0;
+    }
+}

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -26,6 +26,7 @@ import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent
 import org.terasology.ligthandshadow.componentsystem.components.PlayerStatisticsComponent;
 import org.terasology.ligthandshadow.componentsystem.events.GameOverEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.logic.players.PlayerCharacterComponent;
 import org.terasology.logic.players.PlayerUtil;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
@@ -65,17 +66,14 @@ public class ClientGameOverSystem extends BaseComponentSystem {
     private void addPlayerStatisticsInfo(DeathScreen deathScreen) {
         MigLayout migLayout = deathScreen.find("playerStatistics", MigLayout.class);
         if (migLayout != null) {
-            Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
-            for (EntityRef client : clients) {
+            Iterable<EntityRef> characters = entityManager.getEntitiesWith(PlayerCharacterComponent.class, LASTeamComponent.class);
+            for (EntityRef character : characters) {
+                EntityRef client = character.getOwner();
                 ClientComponent clientComponent = client.getComponent(ClientComponent.class);
                 migLayout.addWidget(new UILabel(PlayerUtil.getColoredPlayerName(clientComponent.clientInfo)), new MigLayout.CCHint());
-
-                EntityRef character = client.getComponent(ClientComponent.class).character;
-                if (!character.equals(EntityRef.NULL)) {
-                    PlayerStatisticsComponent playerStatisticsComponent = character.getComponent(PlayerStatisticsComponent.class);
-                    migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.kills)), new MigLayout.CCHint());
-                    migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.deaths)), new MigLayout.CCHint("wrap"));
-                }
+                PlayerStatisticsComponent playerStatisticsComponent = character.getComponent(PlayerStatisticsComponent.class);
+                migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.kills)), new MigLayout.CCHint());
+                migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.deaths)), new MigLayout.CCHint("wrap"));
             }
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -22,11 +23,15 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
+import org.terasology.ligthandshadow.componentsystem.components.PlayerStatisticsComponent;
 import org.terasology.ligthandshadow.componentsystem.events.GameOverEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.logic.players.PlayerUtil;
+import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layers.ingame.DeathScreen;
+import org.terasology.rendering.nui.layouts.miglayout.MigLayout;
 import org.terasology.rendering.nui.widgets.UILabel;
 
 /**
@@ -39,17 +44,38 @@ public class ClientGameOverSystem extends BaseComponentSystem {
     private NUIManager nuiManager;
     @In
     private LocalPlayer localPlayer;
+    @In
+    private EntityManager entityManager;
 
     @ReceiveEvent
     public void onGameOver(GameOverEvent event, EntityRef entity) {
         nuiManager.removeOverlay(LASUtils.ONLINE_PLAYERS_OVERLAY);
         DeathScreen deathScreen = nuiManager.pushScreen(LASUtils.DEATH_SCREEN, DeathScreen.class);
         UILabel gameOverDetails = deathScreen.find("gameOverDetails", UILabel.class);
+        addPlayerStatisticsInfo(deathScreen);
         if (gameOverDetails != null) {
             if (event.winningTeam.equals(localPlayer.getCharacterEntity().getComponent(LASTeamComponent.class).team)) {
                 gameOverDetails.setText("You Win!");
             } else {
                 gameOverDetails.setText("You Lose!");
+            }
+        }
+    }
+
+    private void addPlayerStatisticsInfo(DeathScreen deathScreen) {
+        MigLayout migLayout = deathScreen.find("playerStatistics", MigLayout.class);
+        if (migLayout != null) {
+            Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
+            for (EntityRef client : clients) {
+                ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+                migLayout.addWidget(new UILabel(PlayerUtil.getColoredPlayerName(clientComponent.clientInfo)), new MigLayout.CCHint());
+
+                EntityRef character = client.getComponent(ClientComponent.class).character;
+                if (!character.equals(EntityRef.NULL)) {
+                    PlayerStatisticsComponent playerStatisticsComponent = character.getComponent(PlayerStatisticsComponent.class);
+                    migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.kills)), new MigLayout.CCHint());
+                    migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.deaths)), new MigLayout.CCHint("wrap"));
+                }
             }
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.components.LASTeamComponent;
+import org.terasology.ligthandshadow.componentsystem.components.PlayerStatisticsComponent;
 import org.terasology.logic.characters.AliveCharacterComponent;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
@@ -71,6 +72,8 @@ public class PlayerDeathSystem extends BaseComponentSystem {
         if (player.hasComponent(PlayerCharacterComponent.class)) {
             event.consume();
             String team = player.getComponent(LASTeamComponent.class).team;
+            updateStatistics(event.getInstigator(), "kills");
+            updateStatistics(player, "deaths");
             dropItemsFromInventory(player);
             player.send(new DoHealEvent(100000, player));
             player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
@@ -90,5 +93,16 @@ public class PlayerDeathSystem extends BaseComponentSystem {
                 player.send(new DropItemRequest(slot, player, impulse, deathPosition, count));
             }
         }
+    }
+
+    private void updateStatistics(EntityRef player, String type) {
+        PlayerStatisticsComponent playerStatisticsComponent = player.getComponent(PlayerStatisticsComponent.class);
+        if (type.equals("kills")) {
+            playerStatisticsComponent.kills += 1;
+        }
+        if (type.equals("deaths")) {
+            playerStatisticsComponent.deaths += 1;
+        }
+        player.saveComponent(playerStatisticsComponent);
     }
 }


### PR DESCRIPTION
**Project Cards**:
1. [Game Stats System](https://github.com/orgs/Terasology/projects/17#card-21938065)

**How to test**:  
1. Host a Light and Shadow game
2. Join the game using one more client instance
3. Choose one team with each of the players
4. Play the game! Kill each other, capture the flags
5. The player to collect the flag 5 times first wins!

**Expected outcome**:
The game over screen should now show a list of all players and their kills and deaths.