### PR TITLE
Halt sun on game start

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/LASSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/LASSystem.java
@@ -28,6 +28,7 @@ import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.items.BlockItemFactory;
+import org.terasology.world.sun.CelestialSystem;
 
 @RegisterSystem
 public class LASSystem extends BaseComponentSystem {
@@ -39,6 +40,8 @@ public class LASSystem extends BaseComponentSystem {
     private WorldProvider worldProvider;
     @In
     private BlockManager blockManager;
+    @In
+    private CelestialSystem celestialSystem;
 
     /**
      * Gives player inventory items on game start
@@ -54,6 +57,9 @@ public class LASSystem extends BaseComponentSystem {
 
     @Override
     public void initialise() {
+        if (!celestialSystem.isSunHalted()) {
+            celestialSystem.toggleSunHalting(0.5f);
+        }
     }
 
     @Override


### PR DESCRIPTION
Minor Fix.
# How to test:
1. Start a new game.
Sun should stay on the top all the time.