### PR TITLE
Revert "fix(LightAndShadow): replace perlin with simplex"

### DIFF
--- a/src/main/java/org/terasology/las/LaSWorldGenerator.java
+++ b/src/main/java/org/terasology/las/LaSWorldGenerator.java
@@ -16,7 +16,7 @@
 
 package org.terasology.las;
 
-import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
@@ -134,7 +134,7 @@ public class LaSWorldGenerator extends CityWorldGenerator {
                 .registerFamily(DefaultBlockType.TORCH, "Core:Torch")
                 .build();
 
-        SimplexHumidityProvider.Configuration humidityConfig = new SimplexHumidityProvider.Configuration();
+        PerlinHumidityProvider.Configuration humidityConfig = new PerlinHumidityProvider.Configuration();
         humidityConfig.octaves = 4;
         humidityConfig.scale = 0.5f;
 
@@ -147,7 +147,7 @@ public class LaSWorldGenerator extends CityWorldGenerator {
                 .addProvider(new BuildableTerrainFacetProvider())
                 .addProvider(new BlockedAreaFacetProvider())
                 .addProvider(new LakeFacetProvider())
-                .addProvider(new SimplexHumidityProvider(humidityConfig))
+                .addProvider(new PerlinHumidityProvider(humidityConfig))
                 .addProvider(new SimpleBiomeProvider())
                 .addProvider(new SiteFacetProvider())
                 .addProvider(new TownWallFacetProvider())


### PR DESCRIPTION
Reverts Terasology/LightAndShadow#102
Perlin and Simplex seem to differ in their noise functions. Until we know how to correctly configure Simplex to act like Perlin, this change is reverted and the removed Perlin parts reintroduced and marked as deprecated.