### PR TITLE
Ammo Override UI

### DIFF
--- a/assets/skins/ammoHud.skin
+++ b/assets/skins/ammoHud.skin
@@ -2,7 +2,7 @@
     "inherit": "default",
     "elements": {
         "InventoryCell": {
-            "background": "LightAndShadowResources:ammoArea",
+            "background": "engine:area",
             "background-border": {
                 "top": 4,
                 "bottom": 4,
@@ -17,7 +17,7 @@
             },
             "modes": {
                 "active": {
-                    "background": "LightAndShadowResources:boxActive"
+                    "background": "engine:boxActive"
                 }
             }
         },

--- a/assets/skins/ammoHud.skin
+++ b/assets/skins/ammoHud.skin
@@ -1,0 +1,41 @@
+{
+    "inherit": "default",
+    "elements": {
+        "InventoryCell": {
+            "background": "LightAndShadowResources:ammoArea",
+            "background-border": {
+                "top": 4,
+                "bottom": 4,
+                "left": 4,
+                "right": 4
+            },
+            "margin": {
+                "top": 4,
+                "bottom": 4,
+                "left": 4,
+                "right": 4
+            },
+            "modes": {
+                "active": {
+                    "background": "LightAndShadowResources:boxActive"
+                }
+            }
+        },
+        "TransferItemCursor": {
+            "align-horizontal": "center",
+            "align-vertical": "top"
+        },
+        "ItemIcon": {
+            "fixed-width": 48,
+            "fixed-height": 48,
+            "texture-scale-mode": "scale fit",
+            "text-align-horizontal": "right",
+            "text-align-vertical": "bottom"
+        },
+        "UICrosshair": {
+            "background": "engine:gui#crosshair",
+            "fixed-width": 40,
+            "fixed-height": 40
+        }
+    }
+}

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -1,6 +1,6 @@
 {
     "type": "QuiverHud",
-    "skin": "inventoryDefault",
+    "skin": "ammoHud",
     "contents": {
         "type": "relativeLayout",
         "contents": [

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -1,0 +1,30 @@
+{
+    "type": "QuiverHud",
+    "skin": "inventoryDefault",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "flowLayout",
+                "id": "quiver",
+                "contents": [
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 0
+                    }
+                ],
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-right":{
+                        "target": "RIGHT",
+                        "offset": 100
+                    },
+                    "position-bottom": {
+                        "target": "BOTTOM"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -9,12 +9,16 @@
                 "id": "quiver",
                 "contents": [
                     {
+                        "type": "UILabel",
+                        "text": " AMMO"
+                    },
+                    {
                         "type": "InventoryCell",
                         "targetSlot": 0
                     }
                 ],
                 "layoutInfo": {
-                    "use-content-width": true,
+                    "width": 50,
                     "use-content-height": true,
                     "position-right":{
                         "target": "RIGHT",

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -22,10 +22,11 @@
                     "use-content-height": true,
                     "position-right":{
                         "target": "RIGHT",
-                        "offset": 100
+                        "offset": 150
                     },
                     "position-bottom": {
-                        "target": "BOTTOM"
+                        "target": "BOTTOM",
+                        "offset": 10
                     }
                 }
             }


### PR DESCRIPTION
Associated PR: [Test Assets for LightAndShadow](https://github.com/Terasology/LightAndShadowResources/pull/40)

# Result

The quiver HUD gets Overriden.

## Changes

* Box moved a little bit to the right
* "Ammo" label placed above the box

### Issues

- [X] ~~Ammo box doesn't appear when the game begins (if an item with ammo is the first selected), but you have to change the item and then select back the one with ammo for it to appear~~ **-- Worked on https://github.com/Terasology/CombatSystem/pull/50** 
- [X] ~~I need to figure out how to manipulate label type elements better~~ **-- Resolved within the comment section https://github.com/Terasology/LightAndShadow/pull/125#issuecomment-657079106** 

## How to test

1. Make sure you use the test assets from this `draft` PR: https://github.com/Terasology/LightAndShadowResources/pull/40 
2. Run a LaS game
3. Select the `bow` at quickslot

## Note before merging

### Please make sure that the Ammo slot element does not overlap the quickslot before merging.

## Test UI screenshot

<img width="693" alt="Screenshot_4" src="https://user-images.githubusercontent.com/48293545/85978519-91a03100-b9e7-11ea-8da1-fb123db1cce9.png">