### PR TITLE
Changed used asset for quickslot [Correction of broken version]

### DIFF
--- a/assets/skins/inventoryLaS.skin
+++ b/assets/skins/inventoryLaS.skin
@@ -17,7 +17,7 @@
             },
             "modes": {
                 "active": {
-                    "background": "LightAndShadowResources:boxActive",
+                    "background": "engine:boxActive",
                     "fixed-width": 70,
                     "fixed-height": 70
                 }


### PR DESCRIPTION
# Issue

Quickslot's selected item has no background. This is due to not having the asset yet merged.

# Result

This PR is made to replace that not-yet-merged asset with the default (core) one. 