### PR TITLE
feat(quickslot): sets left-to-right align to quickslot's items

### DIFF
--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -8,7 +8,7 @@
             {
                 "type": "flowLayout",
                 "id": "toolbar",
-                "leftToRightAlign": true,
+                "rightToLeftAlign": true,
                 "verticalSpacing": 10,
                 "contents": [
                     {

--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -8,6 +8,7 @@
             {
                 "type": "flowLayout",
                 "id": "toolbar",
+                "leftToRightAlign": true,
                 "verticalSpacing": 10,
                 "contents": [
                     {


### PR DESCRIPTION
### Before merging

- [x] **`Merge` https://github.com/MovingBlocks/Terasology/pull/4108**

#### Summary

Enables left-to-right widget align for the quickslot's FlowLayout.

#### How to test

1. Check https://github.com/MovingBlocks/Terasology/pull/4108
2. Start a LAS game
3. Notice the quickslot's items _(should get the 1st result screenshot below)_
 
#### Result
![image](https://user-images.githubusercontent.com/48293545/88983903-eb409780-d2d4-11ea-913f-5a3ed54132e4.png) ![image](https://user-images.githubusercontent.com/48293545/88983917-f1367880-d2d4-11ea-96c0-6afd36a49808.png)
