### PR TITLE
feat: reposition of ammo slot

### DIFF
--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -22,7 +22,7 @@
                     "use-content-height": true,
                     "position-right":{
                         "target": "RIGHT",
-                        "offset": 150
+                        "offset": 95
                     },
                     "position-bottom": {
                         "target": "BOTTOM",

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -10,7 +10,7 @@
                 "contents": [
                     {
                         "type": "UILabel",
-                        "text": " AMMO"
+                        "text": "AMMO"
                     },
                     {
                         "type": "InventoryCell",
@@ -22,11 +22,11 @@
                     "use-content-height": true,
                     "position-right":{
                         "target": "RIGHT",
-                        "offset": 95
+                        "offset": 90
                     },
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 10
+                        "offset": 12
                     }
                 }
             }


### PR DESCRIPTION
#### Summary

Brought the ammo slot closer to quickslot. After changing its size at https://github.com/Terasology/LightAndShadowResources/pull/54, I also brought it slightly upwards.

#### How to test

1. Check https://github.com/Terasology/LightAndShadowResources/pull/54
2. Start a LAS game
3. Hold the bow so the ammo slot appears

#### Result

![image](https://user-images.githubusercontent.com/48293545/89038662-70fe2a80-d349-11ea-8d01-bb89c61d33c3.png)