### PR TITLE
fix: dialogue box overlapping the health bar

### DIFF
--- a/overrides/Dialogs/ui/hud/DialogScreen.ui
+++ b/overrides/Dialogs/ui/hud/DialogScreen.ui
@@ -14,7 +14,7 @@
                             "width": 600,
                             "height": 200,
                             "position-bottom": {
-                                "offset": 10
+                                "offset": 50
                             },
                             "position-left": {
                                 "offset": 10

--- a/overrides/Health/ui/hud/healthHud.ui
+++ b/overrides/Health/ui/hud/healthHud.ui
@@ -18,7 +18,7 @@
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": 20
+            "offset": 10
           }
         }
       }


### PR DESCRIPTION
### Summary

Dialogue used to overlap the health bar if the window of the game was small enough. For that reason, the dialogue box had to move upwards.

#### How I chose the new `"offset": 50` for the dialogue box

The `50` consists of the health bar's size (30) and twice the offset of it (the health bar) from the bottom (10). Twice because the health bar should have equal space with the dialogue box, that it has with the bottom of the sreen.

### How to test

1. Start a new LAS game
2. Talk to the Fool NPC
3. Change the whole window's width

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/48293545/89042434-9b52e680-d34f-11ea-9e32-d281f8ac8103.png)
![image](https://user-images.githubusercontent.com/48293545/89042481-ac9bf300-d34f-11ea-97cd-d568f508f5c9.png)

#### After 

![image](https://user-images.githubusercontent.com/48293545/89042343-6f376580-d34f-11ea-8a0c-d66d63625f78.png)
![image](https://user-images.githubusercontent.com/48293545/89042347-7199bf80-d34f-11ea-9621-1dcb7db80bf2.png)
