### PR TITLE
feat: larger quickslot size and ammo slot reposition

### DIFF
--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -22,11 +22,11 @@
                     "use-content-height": true,
                     "position-right":{
                         "target": "RIGHT",
-                        "offset": 90
+                        "offset": 115
                     },
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 12
+                        "offset": 17
                     }
                 }
             }

--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -54,7 +54,7 @@
                     }
                 ],
                 "layoutInfo": {
-                    "width" : 70,
+                    "width" : 90,
                     "use-content-height": true,
                     "position-bottom": {
                         "offset": 10


### PR DESCRIPTION
## Purpose

There has been some changes according to the slot sizes within this PR https://github.com/Terasology/LightAndShadowResources/pull/55

Based on these, there was a need for:
- to upscale the quicklot's width
- to move the ammo slot slightly to the left

Both have been corrected through this PR.
