### PR TITLE
feat: game over screen UI rework

### DIFF
--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -23,7 +23,7 @@
               "contents": [
                 {
                   "type": "UILabel",
-                  "text": "Game Over"
+                  "text": "Game Over:"
                 },
                 {
                   "type": "UILabel",
@@ -129,42 +129,34 @@
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
@@ -408,7 +400,7 @@
             },
             {
               "type": "UIImage",
-              "family": "overOutsideUIBox",
+              "family": "noBackground",
               "image": "LightAndShadowResources:spadesParticle",
               "layoutInfo": {
                 "width": 100,
@@ -423,7 +415,7 @@
             },
             {
               "type": "UIImage",
-              "family": "overOutsideUIBox",
+              "family": "noBackground",
               "image": "LightAndShadowResources:heartsParticle",
               "layoutInfo": {
                 "width": 100,

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -6,7 +6,7 @@
     "contents": [
       {
         "type": "UIBox",
-        "family": "outsideUIBox",
+        "family": "outerUIBox",
         "layoutInfo": {
           "width": 1200,
           "height": 780,
@@ -35,7 +35,7 @@
                   "offset": 20
                 },
                 "position-left": {
-                  "offset": 10
+                  "offset": 20
                 },
                 "use-content-height": true,
                 "width": 450
@@ -44,7 +44,6 @@
             {
               "type": "UIButton",
               "text": "${engine:menu#game-settings}",
-              "family": "UIButtons",
               "id": "settings",
               "layoutInfo": {
                 "position-right": {
@@ -80,7 +79,7 @@
                   {
                     "type": "MigLayout",
                     "id": "titles",
-                    "family": "darkerInnerBoxElement",
+                    "family": "darkerBoxElement",
                     "colConstraints": "[320][125][125][300]",
                     "layoutInfo": {
                       "cc": "cell 0 0 2 1"
@@ -163,7 +162,7 @@
                       },
                       {
                         "type": "MigLayout",
-                        "family": "darkerInnerBoxElement",
+                        "family": "darkerBoxElement",
                         "layoutInfo": {
                           "cc": "dock south"
                         },
@@ -213,7 +212,6 @@
                   },
                   {
                     "type": "MigLayout",
-                    "family": "noBackground",
                     "rowConstraints": "[30][150]",
                     "layoutInfo": {
                       "cc": "cell 0 2"
@@ -268,7 +266,7 @@
                       },
                       {
                         "type": "MigLayout",
-                        "family": "darkerInnerBoxElement",
+                        "family": "darkerBoxElement",
                         "layoutInfo": {
                           "cc": "dock south"
                         },
@@ -323,7 +321,6 @@
               "type": "UIButton",
               "text": "Restart",
               "id": "restart",
-              "family": "UIButtons",
               "visible": false,
               "layoutInfo": {
                 "height": 30,
@@ -340,19 +337,16 @@
             },
             {
               "type": "RowLayout",
-              "family": "noBackground",
               "horizontalSpacing": 15,
               "contents": [
                 {
                   "type": "UIButton",
-                  "family": "UIButtons",
                   "text": "${engine:menu#return-main-menu}",
                   "id": "mainMenu"
                 },
                 {
                   "type": "UIButton",
                   "text": "${engine:menu#exit-game}",
-                  "family": "UIButtons",
                   "id": "exitGame"
                 },
                 {

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -32,11 +32,11 @@
               ],
               "layoutInfo": {
                 "position-top": {
-                  "offset": 36
+                  "offset": 20
                 },
                 "position-left": {},
                 "use-content-height": true,
-                "width": 260
+                "width": 450
               }
             },
             {
@@ -78,6 +78,7 @@
                   {
                     "type": "MigLayout",
                     "id": "titles",
+                    "family": "darkerInnerBoxElement",
                     "colConstraints": "[320][125][125][300]",
                     "layoutInfo": {
                       "cc": "cell 0 0 2 1"
@@ -85,21 +86,25 @@
                     "contents": [
                       {
                         "type": "UISpace",
+                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UILabel",
                         "text": "Kills",
+                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UILabel",
                         "text": "Deaths",
+                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UILabel",
                         "text": "Enemy Flags Captured",
+                        "family": "noBackground",
                         "cc": ""
                       }
                     ]
@@ -112,6 +117,11 @@
                     },
                     "contents": [
                       {
+                        "type": "UIImage",
+                        "image": "LightAndShadowResources:spadesIcon",
+                        "cc": "width ::5!"
+                      },
+                      {
                         "type": "UILabel",
                         "text": "Spades Team",
                         "family": "spadesTeamLabel",
@@ -123,18 +133,59 @@
                         "cc": ""
                       },
                       {
-                        "type": "ScrollableArea",
-                        "id": "gameDetailsScrollableArea",
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "MigLayout",
+                        "family": "darkerInnerBoxElement",
                         "layoutInfo": {
                           "cc": "dock south"
                         },
-                        "content": {
-                          "type": "migLayout",
-                          "id": "spadesTeamPlayerStatistics",
-                          "family": "playerNames",
-                          "rowConstraints": "0",
-                          "colConstraints": "[300][100][100]"
-                        }
+                        "contents": [
+                          {
+                            "type": "ScrollableArea",
+                            "id": "gameDetailsScrollableArea",
+                            "content": {
+                              "type": "migLayout",
+                              "id": "spadesTeamPlayerStatistics",
+                              "family": "playerNames",
+                              "rowConstraints": "0",
+                              "colConstraints": "[300][100][100]"
+                            }
+                          }
+                        ]
                       }
                     ]
                   },
@@ -175,6 +226,11 @@
                     },
                     "contents": [
                       {
+                        "type": "UIImage",
+                        "image": "LightAndShadowResources:heartsIcon",
+                        "cc": "width ::5!"
+                      },
+                      {
                         "type": "UILabel",
                         "text": "Hearts Team",
                         "family": "heartsTeamLabel",
@@ -185,18 +241,65 @@
                         "cc": ""
                       },
                       {
-                        "type": "ScrollableArea",
-                        "id": "gameDetailsScrollableArea2",
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "UISpace",
+                        "family": "noBackground",
+                        "cc": ""
+                      },
+                      {
+                        "type": "MigLayout",
+                        "family": "darkerInnerBoxElement",
                         "layoutInfo": {
                           "cc": "dock south"
                         },
-                        "content": {
-                          "type": "migLayout",
-                          "id": "heartsTeamPlayerStatistics",
-                          "family": "playerNames",
-                          "rowConstraints": "0",
-                          "colConstraints": "[300][100][100]"
-                        }
+                        "contents": [
+                          {
+                            "type": "ScrollableArea",
+                            "family": "darkerInnerBoxElement",
+                            "id": "gameDetailsScrollableArea2",
+                            "content": {
+                              "type": "migLayout",
+                              "id": "heartsTeamPlayerStatistics",
+                              "family": "playerNames",
+                              "rowConstraints": "0",
+                              "colConstraints": "[300][100][100]"
+                            }
+                          }
+                        ]
                       }
                     ]
                   },

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -6,6 +6,7 @@
     "contents": [
       {
         "type": "UIBox",
+        "family": "outsideUIBox",
         "layoutInfo": {
           "width": 1200,
           "height": 780,
@@ -14,10 +15,11 @@
         },
         "content": {
           "type": "relativeLayout",
+          "family": "insideOutsideUIBox",
           "contents": [
             {
               "type": "RowLayout",
-              "horizontalSpacing": 15,
+              "family": "overOutsideUIBox",
               "contents": [
                 {
                   "type": "UILabel",
@@ -40,6 +42,7 @@
             {
               "type": "UIButton",
               "text": "${engine:menu#game-settings}",
+              "family": "UIButtons",
               "id": "settings",
               "layoutInfo": {
                 "position-right": {
@@ -55,6 +58,7 @@
             {
               "type": "UIBox",
               "id": "detailsUIBox",
+              "family": "detailsUIBox",
               "layoutInfo": {
                 "height": 500,
                 "width": 850,
@@ -66,6 +70,7 @@
               },
               "content": {
                 "type": "MigLayout",
+                "family": "noBackground",
                 "layoutConstraints": "",
                 "colConstraints": "[500][350]",
                 "rowConstraints": "[30][200][200]",
@@ -109,10 +114,12 @@
                       {
                         "type": "UILabel",
                         "text": "Spades Team",
+                        "family": "spadesTeamLabel",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
+                        "family": "noBackground",
                         "cc": ""
                       },
                       {
@@ -124,6 +131,7 @@
                         "content": {
                           "type": "migLayout",
                           "id": "spadesTeamPlayerStatistics",
+                          "family": "playerNames",
                           "rowConstraints": "0",
                           "colConstraints": "[300][100][100]"
                         }
@@ -169,6 +177,7 @@
                       {
                         "type": "UILabel",
                         "text": "Hearts Team",
+                        "family": "heartsTeamLabel",
                         "cc": ""
                       },
                       {
@@ -184,6 +193,7 @@
                         "content": {
                           "type": "migLayout",
                           "id": "heartsTeamPlayerStatistics",
+                          "family": "playerNames",
                           "rowConstraints": "0",
                           "colConstraints": "[300][100][100]"
                         }
@@ -226,6 +236,7 @@
               "type": "UIButton",
               "text": "Restart",
               "id": "restart",
+              "family": "UIButtons",
               "visible": false,
               "layoutInfo": {
                 "height": 30,
@@ -246,12 +257,14 @@
               "contents": [
                 {
                   "type": "UIButton",
+                  "family": "UIButtons",
                   "text": "${engine:menu#return-main-menu}",
                   "id": "mainMenu"
                 },
                 {
                   "type": "UIButton",
                   "text": "${engine:menu#exit-game}",
+                  "family": "UIButtons",
                   "id": "exitGame"
                 },
                 {
@@ -292,6 +305,7 @@
             },
             {
               "type": "UIImage",
+              "family": "overOutsideUIBox",
               "image": "LightAndShadowResources:spadesParticle",
               "layoutInfo": {
                 "width": 100,
@@ -306,6 +320,7 @@
             },
             {
               "type": "UIImage",
+              "family": "overOutsideUIBox",
               "image": "LightAndShadowResources:heartsParticle",
               "layoutInfo": {
                 "width": 100,

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -168,7 +168,6 @@
                         "contents": [
                           {
                             "type": "ScrollableArea",
-                            "id": "gameDetailsScrollableArea",
                             "content": {
                               "type": "migLayout",
                               "id": "spadesTeamPlayerStatistics",
@@ -212,6 +211,7 @@
                   },
                   {
                     "type": "MigLayout",
+                    "family": "noBackground",
                     "rowConstraints": "[30][150]",
                     "layoutInfo": {
                       "cc": "cell 0 2"
@@ -234,42 +234,34 @@
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
                         "type": "UISpace",
-                        "family": "noBackground",
                         "cc": ""
                       },
                       {
@@ -281,8 +273,6 @@
                         "contents": [
                           {
                             "type": "ScrollableArea",
-                            "family": "darkerInnerBoxElement",
-                            "id": "gameDetailsScrollableArea2",
                             "content": {
                               "type": "migLayout",
                               "id": "heartsTeamPlayerStatistics",
@@ -348,6 +338,7 @@
             },
             {
               "type": "RowLayout",
+              "family": "noBackground",
               "horizontalSpacing": 15,
               "contents": [
                 {

--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -15,11 +15,11 @@
         },
         "content": {
           "type": "relativeLayout",
-          "family": "insideOutsideUIBox",
+          "family": "noBackground",
           "contents": [
             {
               "type": "RowLayout",
-              "family": "overOutsideUIBox",
+              "family": "gameOverInfo",
               "contents": [
                 {
                   "type": "UILabel",
@@ -34,7 +34,9 @@
                 "position-top": {
                   "offset": 20
                 },
-                "position-left": {},
+                "position-left": {
+                  "offset": 10
+                },
                 "use-content-height": true,
                 "width": 450
               }
@@ -119,7 +121,7 @@
                       {
                         "type": "UIImage",
                         "image": "LightAndShadowResources:spadesIcon",
-                        "cc": "width ::5!"
+                        "cc": ""
                       },
                       {
                         "type": "UILabel",
@@ -220,7 +222,7 @@
                       {
                         "type": "UIImage",
                         "image": "LightAndShadowResources:heartsIcon",
-                        "cc": "width ::5!"
+                        "cc": ""
                       },
                       {
                         "type": "UILabel",
@@ -292,7 +294,7 @@
                       {
                         "type": "UILabel",
                         "id": "heartsTeamScore",
-                        "text": "This is the Hearts Label",
+                        "text": "Hearts Score",
                         "layoutInfo": {
                           "cc": ""
                         }
@@ -307,7 +309,7 @@
                       {
                         "type": "UILabel",
                         "id": "heartsGoalScore",
-                        "text": "6",
+                        "text": "0",
                         "layoutInfo": {
                           "cc": ""
                         }
@@ -391,7 +393,6 @@
             },
             {
               "type": "UIImage",
-              "family": "noBackground",
               "image": "LightAndShadowResources:spadesParticle",
               "layoutInfo": {
                 "width": 100,
@@ -406,7 +407,6 @@
             },
             {
               "type": "UIImage",
-              "family": "noBackground",
               "image": "LightAndShadowResources:heartsParticle",
               "layoutInfo": {
                 "width": 100,


### PR DESCRIPTION
## Purpose

This PR is about modifications according to the design of the Game Over Screen.

## Changes made

* Added a `family` part at the elements within the UI file at the 

## How to test

1. Check https://github.com/Terasology/LightAndShadowResources/pull/56
2. Start a LAS game
3. Choose a team
4. Open the developer tab and gain the enemy team's by writting `give` and `redflag` or `blackflag`
5. Score as many points as you need to finish up the game
6. The Game Over Screen will pop up when you score the last point

_Note:_ You can go to `LAUtils.java` and change `GOAL_SCORE` variable from `5` to `1`, so you need to score 1 point to end the game.

## Current Version

![image](https://user-images.githubusercontent.com/48293545/90937107-49adf100-e40f-11ea-89f3-5b9c4ab1d87c.png)
