### PR TITLE
feat: set a family factor at the UILabel

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -80,8 +80,10 @@ public class ClientGameOverSystem extends BaseComponentSystem {
             if (gameOverResult != null) {
                 if (event.winningTeam.equals(localPlayer.getCharacterEntity().getComponent(LASTeamComponent.class).team)) {
                     gameOverResult.setText("Victory");
+                    gameOverResult.setFamily("win");
                 } else {
                     gameOverResult.setText("Defeat");
+                    gameOverResult.setFamily("lose");
                 }
             }
         }


### PR DESCRIPTION
## Purpose
The change of colors to the `gameOverResult` UILabel. When text is "Victory" its color is Blue, when "Defeat" its color is "Red"

## Changes made

I decided to set the variable to a different `Family`, and edit both families at the `skin` file. 

My initial tried were to set the color via code, using as reference the below two methods that his happens:

- https://github.com/Terasology/Dialogs/blob/develop/src/main/java/org/terasology/dialogs/DialogSystem.java#L173-L174
``` java
mappings.put("player.name", clientInfo.getComponent(DisplayNameComponent.class).name);
mappings.put("player.color", "0x" + clientInfo.getComponent(ColorComponent.class).color.toHex());
```
- https://github.com/Terasology/LightAndShadow/blob/develop/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java#L111-L112
``` java
migLayout.addWidget(new UILabel(PlayerUtil.getColoredPlayerName(clientComponent.clientInfo)),
                new MigLayout.CCHint());
```
## How to test

1. Check https://github.com/Terasology/LightAndShadowResources/pull/57
2. Start a LAS game
3. Choose a team
4. Open the developer tab and gain the enemy team's by writting `give` and `redflag` or `blackflag`
5. Score as many points as you need to finish up the game
6. The Game Over Screen will pop up when you score the last point

_Note:_ You can go to `LAUtils.java` and change `GOAL_SCORE` variable from `5` to `1`, so you need to score 1 point to end the game.

## Screenshot
![image](https://user-images.githubusercontent.com/48293545/91207308-3c477e00-e711-11ea-9a74-1a34410e4ec5.png)
