### PR TITLE
feat: added outer border to the game over screen

### DIFF
--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -6,7 +6,7 @@
     "contents": [
       {
         "type": "UIBox",
-        "family": "outerUIBox",
+        "family": "detailsUIBox",
         "layoutInfo": {
           "width": 1200,
           "height": 780,
@@ -15,7 +15,7 @@
         },
         "content": {
           "type": "relativeLayout",
-          "family": "noBackground",
+          "family": "outerUIBox",
           "contents": [
             {
               "type": "RowLayout",


### PR DESCRIPTION
## Purpose
I added a border (color green) at the outside of the wider UIBox.

## Changes made
I change the outer UIBox's and outer RelativeLayout's `family`s. The RelativeLayout got the `family` with the white background and the UIBox got the `family` with the green background.

## How to test

1. Check https://github.com/Terasology/LightAndShadowResources/pull/58
2. Start a LAS game
3. Choose a team
4. Open the developer tab and gain the enemy team's by writting `give` and `redflag` or `blackflag`
5. Score as many points as you need to finish up the game
6. The Game Over Screen will pop up when you score the last point

_Note:_ You can go to `LAUtils.java` and change `GOAL_SCORE` variable from `5` to `1`, so you need to score 1 point to end the game.

## Screenshot
![image](https://user-images.githubusercontent.com/48293545/91220697-35c30180-e725-11ea-9a47-51922e24b673.png)
