### PR TITLE
fix: image's column height

### DIFF
--- a/overrides/Dialogs/ui/hud/DialogScreen.ui
+++ b/overrides/Dialogs/ui/hud/DialogScreen.ui
@@ -51,9 +51,9 @@
                     {
                         "type": "ColumnLayout",
                         "id": "responseImage",
-                        "family": "imageColumn",
                         "layoutInfo": {
                             "use-content-width": true,
+                            "use-content-height": true,
                             "position-top": {
                                 "target": "TOP",
                                 "widget": "box"


### PR DESCRIPTION
## Associated
This PR fixes the same issue but within LAS: https://github.com/Terasology/Dialogs/pull/19

## Description

- An issue with Answer Image positioning:
Even if there was no issue in previous tests, this time it seemed that the positioning was off

## Changes

### For Issue
I believe the issue was that I set a `family` with fixed height at the column hosting the answer images, which family was meant to set a fixed size at the answer UIImages. What I did, was to remove the family from the column, and add it via code to each new UIImage added before the answer UIButtons.

### How to test

1. ~~Check https://github.com/Terasology/Dialogs/pull/18~~
2. Talk to the NPC (The Fool) in front of you when you start the game
