### PR TITLE
Update Death Counter Due To Fall Damage

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -72,7 +72,9 @@ public class PlayerDeathSystem extends BaseComponentSystem {
         if (player.hasComponent(PlayerCharacterComponent.class)) {
             event.consume();
             String team = player.getComponent(LASTeamComponent.class).team;
-            updateStatistics(event.getInstigator(), "kills");
+            if(event.getInstigator().getComponent(PlayerStatisticsComponent.class)!=null) {
+                updateStatistics(event.getInstigator(), "kills");
+            }
             updateStatistics(player, "deaths");
             dropItemsFromInventory(player);
             player.send(new RestoreFullHealthEvent(player));


### PR DESCRIPTION
### Contains
"Fixes #145"
Updates the death counter every time the player dies due to fall damage.


### How to test
In game give fall damage to the player until the player dies.

### Outstanding before merging
- [x] Update the death counter due to fall damage
- [ ] Teleport back to the base on death