### PR TITLE
Remove previous scores after restarting game

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
@@ -42,5 +42,4 @@ public class PlayerStatisticsComponent implements Component {
     public void setDeaths(int deaths) {
         this.deaths = deaths;
     }
-
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
@@ -34,4 +34,13 @@ public class PlayerStatisticsComponent implements Component {
         this.kills = 0;
         this.deaths = 0;
     }
+
+    public void setKills(int kills) {
+        this.kills = kills;
+    }
+
+    public void setDeaths(int deaths) {
+        this.deaths = deaths;
+    }
+
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/components/PlayerStatisticsComponent.java
@@ -34,12 +34,4 @@ public class PlayerStatisticsComponent implements Component {
         this.kills = 0;
         this.deaths = 0;
     }
-
-    public void setKills(int kills) {
-        this.kills = kills;
-    }
-
-    public void setDeaths(int deaths) {
-        this.deaths = deaths;
-    }
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -117,6 +117,8 @@ public class ClientGameOverSystem extends BaseComponentSystem {
         migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.kills)), new MigLayout.CCHint());
         migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.deaths)), new MigLayout.CCHint("wrap"
         ));
+	playerStatisticsComponent.setKills(0);
+        playerStatisticsComponent.setDeaths(0);
     }
 
     private void addFlagInfo(DeathScreen deathScreen, GameOverEvent event) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -117,8 +117,8 @@ public class ClientGameOverSystem extends BaseComponentSystem {
         migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.kills)), new MigLayout.CCHint());
         migLayout.addWidget(new UILabel(String.valueOf(playerStatisticsComponent.deaths)), new MigLayout.CCHint("wrap"
         ));
-	playerStatisticsComponent.setKills(0);
-        playerStatisticsComponent.setDeaths(0);
+        playerStatisticsComponent.kills=0;
+        playerStatisticsComponent.deaths=0;
     }
 
     private void addFlagInfo(DeathScreen deathScreen, GameOverEvent event) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -92,6 +92,8 @@ public class ClientGameOverSystem extends BaseComponentSystem {
     private void addPlayerStatisticsInfo(DeathScreen deathScreen, GameOverEvent event) {
         MigLayout spadesTeamMigLayout = deathScreen.find("spadesTeamPlayerStatistics", MigLayout.class);
         MigLayout heartsTeamMigLayout = deathScreen.find("heartsTeamPlayerStatistics", MigLayout.class);
+	spadesTeamMigLayout.removeAllWidgets();
+        heartsTeamMigLayout.removeAllWidgets();
         if (spadesTeamMigLayout != null && heartsTeamMigLayout != null) {
             Iterable<EntityRef> characters = entityManager.getEntitiesWith(PlayerCharacterComponent.class,
                     LASTeamComponent.class);


### PR DESCRIPTION
### Contains
"Fixes #151"
The screen with the players and scores from the previously played games are reset when the game is restarted.


### How to test
Complete a game once and then restart the game and complete it once again.

### Outstanding before merging
- [x] Previous game scores do not persist