### PR TITLE
Allows all players to restart the game after 10 seconds

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -73,7 +73,6 @@ public final class LASUtils {
     public static final String DEATH_SCREEN = "engine:DeathScreen";
     public static final String ONLINE_PLAYERS_OVERLAY = "engine:onlinePlayersOverlay";
 
-    public static final String RESTART_PERMISSION = "restart";
     public static final String DROPPED_FLAG = "dropped_flag_indicator";
     public static final long FLAG_TELEPORT_DELAY = 20000;
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
@@ -27,7 +27,6 @@ import org.terasology.ligthandshadow.componentsystem.events.ClientRestartEvent;
 import org.terasology.ligthandshadow.componentsystem.events.RestartRequestEvent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.health.event.RestoreFullHealthEvent;
-import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
@@ -43,8 +42,6 @@ public class RestartSystem extends BaseComponentSystem {
     EntityManager entityManager;
     @In
     NUIManager nuiManager;
-    @In
-    PermissionManager permissionManager;
 
     /**
      * System to invoke restart. Only the host can restart the game.
@@ -55,7 +52,6 @@ public class RestartSystem extends BaseComponentSystem {
      */
     @ReceiveEvent(netFilter = RegisterMode.AUTHORITY)
     public void onRestartRequest(RestartRequestEvent event, EntityRef clientEntity, ClientComponent clientComponent) {
-        if (permissionManager.hasPermission(clientComponent.clientInfo, LASUtils.RESTART_PERMISSION)) {
             Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
             for (EntityRef client: clients) {
                 EntityRef player = client.getComponent(ClientComponent.class).character;
@@ -64,7 +60,6 @@ public class RestartSystem extends BaseComponentSystem {
                 player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
                 client.send(new ClientRestartEvent());
             }
-        }
     }
 
     /**

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/RestartSystem.java
@@ -44,7 +44,7 @@ public class RestartSystem extends BaseComponentSystem {
     NUIManager nuiManager;
 
     /**
-     * System to invoke restart. Only the host can restart the game.
+     * System to invoke restart of a game round.
      * All players' health are restored and they are transported back to their bases.
      *
      * @param event

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
@@ -102,12 +102,10 @@ public class ScoreSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onRestartRequest(RestartRequestEvent event, EntityRef clientEntity, ClientComponent clientComponent) {
-        if (permissionManager.hasPermission(clientComponent.clientInfo, LASUtils.RESTART_PERMISSION)) {
-            redScore = 0;
-            blackScore = 0;
-            sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.RED_TEAM, redScore));
-            sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.BLACK_TEAM, blackScore));
-        }
+        redScore = 0;
+        blackScore = 0;
+        sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.RED_TEAM, redScore));
+        sendEventToClients(new ScoreUpdateFromServerEvent(LASUtils.BLACK_TEAM, blackScore));
     }
 
     private void checkAndResetGameOnScore(ActivateEvent event, EntityRef entity) {

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ScoreSystem.java
@@ -143,9 +143,7 @@ public class ScoreSystem extends BaseComponentSystem {
         if (entityManager.getCountOfEntitiesWith(ClientComponent.class) != 0) {
             Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
             for (EntityRef client : clients) {
-                EntityRef clientInfo = client.getComponent(ClientComponent.class).clientInfo;
-                Boolean hasRestartPermission = permissionManager.hasPermission(clientInfo, LASUtils.RESTART_PERMISSION);
-                client.send(new GameOverEvent(winningTeam, hasRestartPermission, blackScore, redScore));
+                client.send(new GameOverEvent(winningTeam, blackScore, redScore));
             }
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/GameOverEvent.java
@@ -24,16 +24,14 @@ import org.terasology.network.OwnerEvent;
 @OwnerEvent
 public class GameOverEvent implements Event {
     public String winningTeam;
-    public Boolean hasRestartPermission;
     public int blackTeamScore;
     public int redTeamScore;
 
     public GameOverEvent() {
     }
 
-    public GameOverEvent(String winningTeam, Boolean hasRestartPermission, int blackTeamScore, int redTeamScore) {
+    public GameOverEvent(String winningTeam, int blackTeamScore, int redTeamScore) {
         this.winningTeam = winningTeam;
-        this.hasRestartPermission = hasRestartPermission;
         this.blackTeamScore = blackTeamScore;
         this.redTeamScore = redTeamScore;
     }


### PR DESCRIPTION
### Contains
"Fixes #154"
Allows all the players to restart the game. The restart button appears after 10 seconds allowing the players to check their stats in the mean time.


### How to test
Host and Join a multiplayer game using 2 or more host/clients and once the game is completed everybody should be able to restart the game.

### Outstanding before merging
- [x] Allow everybody to restart the game.