### PR TITLE
Add a timer to indicate when the restart button gets enabled

### DIFF
--- a/overrides/engine/ui/ingame/deathScreen.ui
+++ b/overrides/engine/ui/ingame/deathScreen.ui
@@ -336,6 +336,26 @@
               }
             },
             {
+              "type": "UILabel",
+              "text": "Timer",
+              "family": "noBackground",
+              "id": "timer",
+              "layoutInfo": {
+                "height": 30,
+                "width": 45,
+                "position-top": {
+                  "target": "BOTTOM",
+                  "widget": "detailsUIBox",
+                  "offset": 10
+                },
+                "position-left": {
+                  "target": "LEFT",
+                  "widget": "restart",
+                  "offset": 90
+                }
+              }
+            },
+            {
               "type": "RowLayout",
               "horizontalSpacing": 15,
               "contents": [

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -87,8 +87,10 @@ public class ClientGameOverSystem extends BaseComponentSystem {
                     int timePeriod = 10;
                     public void run() {
                         countDown.setText(Integer.toString(timePeriod--));
-                        if (timePeriod < 0)
+                        if (timePeriod < 0) {
+                            countDown.setText(" ");
                             timer.cancel();
+                        }
                     }
                 }, 0, 1000);
                 restartButton.setVisible(true);

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientGameOverSystem.java
@@ -17,6 +17,8 @@ package org.terasology.ligthandshadow.componentsystem.controllers;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 
 import org.terasology.entitySystem.entity.EntityManager;
@@ -60,6 +62,8 @@ public class ClientGameOverSystem extends BaseComponentSystem {
         return thread;
     });
 
+    private static Timer timer;
+
     /**
      * System to show game over screen once a team achieves goal score.
      *
@@ -76,9 +80,20 @@ public class ClientGameOverSystem extends BaseComponentSystem {
             UILabel gameOverResult = deathScreen.find("gameOverResult", UILabel.class);
 
             UIButton restartButton = deathScreen.find("restart", UIButton.class);
-            if (restartButton != null) {
-                restartButton.setVisible(false);
-                executorService.schedule(() -> restartButton.setVisible(true), 10, TimeUnit.SECONDS);
+            UILabel countDown = deathScreen.find("timer", UILabel.class);
+            if (restartButton != null && countDown != null) {
+                timer = new Timer();
+                timer.scheduleAtFixedRate(new TimerTask() {
+                    int timePeriod = 10;
+                    public void run() {
+                        countDown.setText(Integer.toString(timePeriod--));
+                        if (timePeriod < 0)
+                            timer.cancel();
+                    }
+                }, 0, 1000);
+                restartButton.setVisible(true);
+                restartButton.setEnabled(false);
+                executorService.schedule(() -> restartButton.setEnabled(true), 10, TimeUnit.SECONDS);
             }
 
             WidgetUtil.trySubscribe(deathScreen, "restart", widget -> triggerRestart());


### PR DESCRIPTION
### Contains
Adds a timer to show when the the restart button will be enabled.


### How to test
In addition to this PR check Terasology/LightAndShadowResources#60.
Join a single player or multiplayer game and when the game is over a timer should appear to show when the restart button will be enabled.

### Outstanding before merging
- [x] Timer to show when restart button will be enabled.