### PR TITLE
feat: Replace SurfaceHeightFacet with SurfacesFacet and ElevationFacet

### DIFF
--- a/src/main/java/org/terasology/las/LaSSurfaceProvider.java
+++ b/src/main/java/org/terasology/las/LaSSurfaceProvider.java
@@ -21,9 +21,9 @@ import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.ElevationFacet;
 
-@Produces(SurfaceHeightFacet.class)
+@Produces(ElevationFacet.class)
 public class LaSSurfaceProvider implements FacetProvider {
 
     @Override
@@ -33,17 +33,17 @@ public class LaSSurfaceProvider implements FacetProvider {
     @Override
     public void process(GeneratingRegion region) {
         // Create our surface height facet (we will get into borders later)
-        Border3D border = region.getBorderForFacet(SurfaceHeightFacet.class);
-        SurfaceHeightFacet facet = new SurfaceHeightFacet(region.getRegion(), border);
+        Border3D border = region.getBorderForFacet(ElevationFacet.class);
+        ElevationFacet facet = new ElevationFacet(region.getRegion(), border);
 
         // Loop through every position in our 2d array
         Rect2i processRegion = facet.getWorldRegion();
         for (BaseVector2i position : processRegion.contents()) {
-            facet.setWorld(position, 9f);
+            facet.setWorld(position, 9.5f);
         }
 
         // Pass our newly created and populated facet to the region
-        region.setRegionFacet(SurfaceHeightFacet.class, facet);
+        region.setRegionFacet(ElevationFacet.class, facet);
     }
 
 

--- a/src/main/java/org/terasology/las/MountainsProvider.java
+++ b/src/main/java/org/terasology/las/MountainsProvider.java
@@ -16,10 +16,10 @@ import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Requires;
 import org.terasology.world.generation.Updates;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.ElevationFacet;
 
 @Requires(@Facet(PlayAreaFacet.class))
-@Updates(@Facet(SurfaceHeightFacet.class))
+@Updates(@Facet(ElevationFacet.class))
 public class MountainsProvider implements FacetProvider {
     private Noise mountainNoise;
 
@@ -31,7 +31,7 @@ public class MountainsProvider implements FacetProvider {
 
     @Override
     public void process(GeneratingRegion region) {
-        SurfaceHeightFacet facet = region.getRegionFacet(SurfaceHeightFacet.class);
+        ElevationFacet facet = region.getRegionFacet(ElevationFacet.class);
         PlayAreaFacet playAreaFacet = region.getRegionFacet(PlayAreaFacet.class);
         float mountainHeight = 40;
 

--- a/src/main/java/org/terasology/las/bases/BaseProvider.java
+++ b/src/main/java/org/terasology/las/bases/BaseProvider.java
@@ -20,18 +20,13 @@ import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.generation.Border3D;
-import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.Requires;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
 
 import java.util.Collection;
 
 @Produces(BaseFacet.class)
-@Requires(@Facet(SurfaceHeightFacet.class))
-
 public class BaseProvider implements FacetProvider {
     Region3i redBaseRegion = CreateBaseRegionFromVector(LASUtils.CENTER_RED_BASE_POSITION);
     Region3i blackBaseRegion = CreateBaseRegionFromVector(LASUtils.CENTER_BLACK_BASE_POSITION);

--- a/src/main/java/org/terasology/las/yinyang/YinYangProvider.java
+++ b/src/main/java/org/terasology/las/yinyang/YinYangProvider.java
@@ -5,13 +5,9 @@ package org.terasology.las.yinyang;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.generation.Border3D;
-import org.terasology.world.generation.Facet;
-import org.terasology.world.generation.FacetBorder;
 import org.terasology.world.generation.FacetProviderPlugin;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.Requires;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generator.plugin.RegisterPlugin;
 
 import java.util.Collections;
@@ -19,7 +15,6 @@ import java.util.List;
 
 @RegisterPlugin
 @Produces(YinYangFacet.class)
-@Requires(@Facet(value = SurfaceHeightFacet.class, border = @FacetBorder(sides = 10)))
 public class YinYangProvider implements FacetProviderPlugin {
 
     private List<Vector3i> yinYangPositions = Collections.singletonList(new Vector3i(0, 10, 0));


### PR DESCRIPTION
Update for https://github.com/MovingBlocks/Terasology/pull/4237.

Mostly this is just a straightforward replacement of the occurrences of SurfaceHeightFacet. In a few places it was listed as required but wasn't actually used, and the CoreWorlds PR for this update changed the ground rasteriser so blocks whose heights are exactly the elevation value are air, so the elevation had to be increased slightly to compensate.