### PR TITLE
feat: remove minimap

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -16,7 +16,6 @@
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "ItemRendering", "minVersion": "1.1.0" },
         { "id": "LightAndShadowResources", "minVersion": "1.0.0" },
-        { "id": "Minimap", "minVersion": "1.0.0" },
         { "id": "Pathfinding", "minVersion": "1.0.0" },
         { "id": "StaticCities", "minVersion": "1.0.0" },
         { "id": "StructuralResources", "minVersion": "2.1.0" },

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -63,8 +63,6 @@ public final class LASUtils {
     public static final String WHITE_HEALTH_SKIN = "lightAndShadowResources:healthWhite";
     public static final String RED_HEALTH_SKIN = "lightAndShadowResources:healthRed";
     public static final String BLACK_HEALTH_SKIN = "lightAndShadowResources:healthBlack";
-    public static final String RED_MINIMAP_ICON = "lightAndShadowResources:heartsIcon";
-    public static final String BLACK_MINIMAP_ICON = "lightAndShadowResources:spadesIcon";
     // The position near the team's base that player will be teleported to on choosing a team
     public static final Vector3f RED_TELEPORT_DESTINATION = new Vector3f(29, 12, 0);
     public static final Vector3f BLACK_TELEPORT_DESTINATION = new Vector3f(-29, 12, 0);
@@ -166,16 +164,6 @@ public final class LASUtils {
         }
         if (team.equals(BLACK_TEAM)) {
             return RED_TEAM;
-        }
-        return null;
-    }
-
-    public static String getMinimapIcon(String team) {
-        if (team.equals(RED_TEAM)) {
-            return RED_MINIMAP_ICON;
-        }
-        if (team.equals(BLACK_TEAM)) {
-            return BLACK_MINIMAP_ICON;
         }
         return null;
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -27,7 +27,6 @@ import org.terasology.ligthandshadow.componentsystem.components.SetTeamOnActivat
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
-import org.terasology.minimap.MinimapIconComponent;
 import org.terasology.registry.In;
 
 /**
@@ -54,7 +53,6 @@ public class TeleporterSystem extends BaseComponentSystem {
     public void onActivate(ActivateEvent event, EntityRef entity) {
         EntityRef player = event.getInstigator();
         String team = setPlayerTeamToTeleporterTeam(player, entity);
-        setPlayerMinimapIcon(player, team);
         handlePlayerTeleport(player, team);
     }
 
@@ -64,14 +62,6 @@ public class TeleporterSystem extends BaseComponentSystem {
         playerTeamComponent.team = teleporterTeamComponent.team;
         player.saveComponent(playerTeamComponent);
         return playerTeamComponent.team;
-    }
-
-    private void setPlayerMinimapIcon(EntityRef player, String team) {
-        MinimapIconComponent minimapIconComponent = player.getComponent(MinimapIconComponent.class);
-        if (minimapIconComponent != null) {
-            minimapIconComponent.iconUrn = LASUtils.getMinimapIcon(team);
-            player.saveComponent(minimapIconComponent);
-        }
     }
 
     private void handlePlayerTeleport(EntityRef player, String team) {


### PR DESCRIPTION
The current LaS arena is very small and provides a limited set of strategic possibilities to prevent the opposing team from getting to the flag and bring it back to their base.
One of the strategic possibilities is to obfuscate where the own team members are located for instance by hiding behind generated world elements such as trees or by building barricades.
With `Minimap` in play, this strategy is not possible as the location of players is always visible. 

This is why I propose to remove `Minimap` from `LightAndShadow`.
Once we create additional play arenas in which `Minimap` would be beneficial again, it can easily be re-integrated. Ideally, we could then make the use of `Minimap` a configurable setting, so that players can decide themselves whether they want to play with it or without. Currently, this alternative is not feasible as the gameplay configuration possibilities are limited if not broken.