### PR TITLE
fix: LaSFloraRasterizer references to deprecated `core` module

### DIFF
--- a/src/main/java/org/terasology/las/LaSFloraRasterizer.java
+++ b/src/main/java/org/terasology/las/LaSFloraRasterizer.java
@@ -29,9 +29,9 @@ public class LaSFloraRasterizer extends FloraRasterizer {
         air = blockManager.getBlock(BlockManager.AIR_ID);
 
         flora.put(FloraType.GRASS, ImmutableList.<Block>of(
-                blockManager.getBlock("core:TallGrass1"),
-                blockManager.getBlock("core:TallGrass2"),
-                blockManager.getBlock("core:TallGrass3")));
+                blockManager.getBlock("CoreAssets:TallGrass1"),
+                blockManager.getBlock("CoreAssets:TallGrass2"),
+                blockManager.getBlock("CoreAssets:TallGrass3")));
 
         flora.put(FloraType.FLOWER, ImmutableList.<Block>of(
                 blockManager.getBlock("lightAndShadowResources:spadesCropSapling"),
@@ -42,9 +42,9 @@ public class LaSFloraRasterizer extends FloraRasterizer {
 
 
         flora.put(FloraType.MUSHROOM, ImmutableList.<Block>of(
-                blockManager.getBlock("core:BigBrownShroom"),
-                blockManager.getBlock("core:BrownShroom"),
-                blockManager.getBlock("core:RedShroom")));
+                blockManager.getBlock("CoreAssets:BigBrownShroom"),
+                blockManager.getBlock("CoreAssets:BrownShroom"),
+                blockManager.getBlock("CoreAssets:RedShroom")));
     }
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29981695/99876487-41747600-2bf7-11eb-9341-3c8586a6b5d8.png)
