### PR TITLE
fix: adjust height of player nametag

### DIFF
--- a/deltas/engine/prefabs/player/player.prefab
+++ b/deltas/engine/prefabs/player/player.prefab
@@ -1,4 +1,7 @@
 {
+    "Character": {
+        "nameTagOffset": 1.7
+    },
     "LASTeam" : {
         "team" : "white"
     },


### PR DESCRIPTION
The name tag was floating in the pawn model model, making it unreadable.

![Terasology-201125221148-1279x675](https://user-images.githubusercontent.com/1448874/100282619-3f4e4680-2f6c-11eb-8803-1509d91afb2b.png)
