### PR TITLE
feat: Randomize player respawn location

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -81,7 +81,7 @@ public class PlayerDeathSystem extends BaseComponentSystem {
             updateStatistics(player, "deaths");
             dropItemsFromInventory(player);
             player.send(new RestoreFullHealthEvent(player));
-            Vector3f randomVector = new Vector3f(-1 + random.nextInt(4), 0, -1 + random.nextInt(4));
+            Vector3f randomVector = new Vector3f(-1 + random.nextInt(3), 0, -1 + random.nextInt(3));
             player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -81,7 +81,7 @@ public class PlayerDeathSystem extends BaseComponentSystem {
             updateStatistics(player, "deaths");
             dropItemsFromInventory(player);
             player.send(new RestoreFullHealthEvent(player));
-            Vector3f randomVector = new Vector3f(-2 + random.nextInt(4), 0, -2 + random.nextInt(4));
+            Vector3f randomVector = new Vector3f(-1 + random.nextInt(4), 0, -1 + random.nextInt(4));
             player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         }
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/PlayerDeathSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
+import java.util.Random;
+
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.terasology.assets.management.AssetManager;
@@ -58,6 +60,8 @@ public class PlayerDeathSystem extends BaseComponentSystem {
     @In
     private BlockManager blockManager;
 
+    private Random random = new Random();
+
     /**
      * Empty the inventory and send player player back to its base with refilled health.
      * This is a high priority method, hence it receives the event first and consumes it.
@@ -77,7 +81,8 @@ public class PlayerDeathSystem extends BaseComponentSystem {
             updateStatistics(player, "deaths");
             dropItemsFromInventory(player);
             player.send(new RestoreFullHealthEvent(player));
-            player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
+            Vector3f randomVector = new Vector3f(-2 + random.nextInt(4), 0, -2 + random.nextInt(4));
+            player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         }
     }
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -70,7 +70,7 @@ public class TeleporterSystem extends BaseComponentSystem {
     }
 
     private void handlePlayerTeleport(EntityRef player, String team) {
-        Vector3f randomVector = new Vector3f(-2 + random.nextInt(4), 0, -2 + random.nextInt(4));
+        Vector3f randomVector = new Vector3f(-1 + random.nextInt(4), 0, -1 + random.nextInt(4));
         player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(LASUtils.MAGIC_STAFF_URI));
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -70,7 +70,7 @@ public class TeleporterSystem extends BaseComponentSystem {
     }
 
     private void handlePlayerTeleport(EntityRef player, String team) {
-        Vector3f randomVector = new Vector3f(-1 + random.nextInt(4), 0, -1 + random.nextInt(4));
+        Vector3f randomVector = new Vector3f(-1 + random.nextInt(3), 0, -1 + random.nextInt(3));
         player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(LASUtils.MAGIC_STAFF_URI));
     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
+import java.util.Random;
+
+import org.joml.Vector3f;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.ReceiveEvent;
@@ -42,6 +45,8 @@ public class TeleporterSystem extends BaseComponentSystem {
     @In
     EntityManager entityManager;
 
+    private Random random = new Random();
+
     /**
      * Depending on which teleporter the player chooses, they are set to that team
      * and teleported to that base
@@ -65,7 +70,8 @@ public class TeleporterSystem extends BaseComponentSystem {
     }
 
     private void handlePlayerTeleport(EntityRef player, String team) {
-        player.send(new CharacterTeleportEvent(LASUtils.getTeleportDestination(team)));
+        Vector3f randomVector = new Vector3f(-2 + random.nextInt(4), 0, -2 + random.nextInt(4));
+        player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
         inventoryManager.giveItem(player, EntityRef.NULL, entityManager.create(LASUtils.MAGIC_STAFF_URI));
     }
 }


### PR DESCRIPTION
### Contains
"Fixes #85"
Respawn the player at random locations on the base so that teamates don't spawn on top of each other.


### How to test
In  singleplayer mode in console type kill to kill the player multiple times, he should respawn at different positions each of those times. 

### Outstanding before merging
- [x] Randomize player respawn.