### PR TITLE
Raise Floating Platform so trees cannot penetrate/collide with it.

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -29,6 +29,7 @@ public final class LASUtils {
     /**
      * Floating Platform values
      */
+
     public static final int FLOATING_PLATFORM_HEIGHT_LEVEL = 90;
     public static final Vector3ic FLOATING_PLATFORM_POSITION = new Vector3i(0, FLOATING_PLATFORM_HEIGHT_LEVEL, 252);
     public static final int FLOATING_PLATFORM_WIDTH = 28;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/LASUtils.java
@@ -29,10 +29,10 @@ public final class LASUtils {
     /**
      * Floating Platform values
      */
-    public static final Vector3ic FLOATING_PLATFORM_POSITION = new Vector3i(0, 60, 252);
+    public static final int FLOATING_PLATFORM_HEIGHT_LEVEL = 90;
+    public static final Vector3ic FLOATING_PLATFORM_POSITION = new Vector3i(0, FLOATING_PLATFORM_HEIGHT_LEVEL, 252);
     public static final int FLOATING_PLATFORM_WIDTH = 28;
     public static final int FLOATING_PLATFORM_LENGTH = 56;
-    public static final int FLOATING_PLATFORM_HEIGHT_LEVEL = 60;
     public static final int TELEPORTER_OFFSET = 4;
     public static final int NPC_OFFSET = 24;
     /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57260557/114326904-de7f6f00-9b04-11eb-9657-232c4ba0009a.png)
The above image illustrates a bug present where trees can sometimes grow tall enough to penetrate/collide with the floating platform.

MountainProvider can elevate terrain up to y= 50 units. The tallest tree, the birch, is 35 units tall. Currently the floating platform spawns at y=60. By setting the floating platform height to 90, the floating platform is guaranteed to be higher than the tallest tree at the highest elevation.