### PR TITLE
fix: adjust vertical alignment of inventory quickslot

### DIFF
--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -20,13 +20,13 @@
                 "layoutInfo": {
                     "width": 50,
                     "use-content-height": true,
-                    "position-right":{
+                    "position-right": {
                         "target": "RIGHT",
-                        "offset": 115
+                        "offset": 25
                     },
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 17
+                        "offset": 35
                     }
                 }
             }

--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -22,11 +22,11 @@
                     "use-content-height": true,
                     "position-right": {
                         "target": "RIGHT",
-                        "offset": 25
+                        "offset": 115
                     },
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 35
+                        "offset": 17
                     }
                 }
             }

--- a/overrides/Health/ui/hud/healthHud.ui
+++ b/overrides/Health/ui/hud/healthHud.ui
@@ -18,7 +18,7 @@
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": 5
+            "offset": 10
           }
         }
       }

--- a/overrides/Health/ui/hud/healthHud.ui
+++ b/overrides/Health/ui/hud/healthHud.ui
@@ -18,7 +18,7 @@
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": 10
+            "offset": 5
           }
         }
       }

--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -8,40 +8,12 @@
             {
                 "type": "flowLayout",
                 "id": "toolbar",
+                "topToBottomAlign": true,
                 "rightToLeftAlign": true,
                 "contents": [
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 0,
-                        "selected": true
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 1
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 2
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 3
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 4
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 5
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 6
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 7
+                        "targetSlot": 9
                     },
                     {
                         "type": "InventoryCell",
@@ -49,7 +21,36 @@
                     },
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 9
+                        "targetSlot": 7
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 6
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 5
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 4
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 3
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 2
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 1
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 0,
+                        "selected": true
                     }
                 ],
                 "layoutInfo": {
@@ -57,11 +58,11 @@
                     "use-content-width": true,
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 35
+                        "offset": 10
                     },
                     "position-right": {
                         "target": "RIGHT",
-                        "offset": 75
+                        "offset": 10
                     }
                 }
             },

--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -9,39 +9,11 @@
                 "type": "flowLayout",
                 "id": "toolbar",
                 "rightToLeftAlign": true,
-                "verticalSpacing": 10,
                 "contents": [
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 9
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 8
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 7
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 6
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 5
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 4
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 3
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 2
+                        "targetSlot": 0,
+                        "selected": true
                     },
                     {
                         "type": "InventoryCell",
@@ -49,18 +21,47 @@
                     },
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 0,
-                        "selected": true
+                        "targetSlot": 2
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 3
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 4
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 5
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 6
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 7
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 8
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 9
                     }
                 ],
                 "layoutInfo": {
-                    "width" : 90,
                     "use-content-height": true,
+                    "use-content-width": true,
                     "position-bottom": {
-                        "offset": 10
+                        "target": "BOTTOM",
+                        "offset": 35
                     },
                     "position-right": {
-                        "offset": 10
+                        "target": "RIGHT",
+                        "offset": 75
                     }
                 }
             },


### PR DESCRIPTION
Implements fix for issue [https://github.com/Terasology/LightAndShadow/issues/153](https://github.com/Terasology/LightAndShadow/issues/153) using the TeraNUI's updated FlowLayout.
Won't work unless the TeraNUI FlowLayout pull request, [https://github.com/MovingBlocks/TeraNUI/pull/53](https://github.com/MovingBlocks/TeraNUI/pull/53), is accepted. 