### PR TITLE
fix: reintroduce Tasks dep

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -53,6 +53,10 @@
         {
             "id": "Pathfinding",
             "minVersion": "1.0.0"
+        },
+        {
+            "id": "Tasks",
+            "minVersion": "1.0.0"
         }
     ],
     "isServerSideOnly": false,


### PR DESCRIPTION
- LaS defines a delta of Tasks:BeaconMark
- as deltas only mention the module of the original asset on the file path, it was overlooked in #207