### PR TITLE
feat: use item activation (right click) for magic staff

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/AttackSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/AttackSystem.java
@@ -3,8 +3,6 @@
 
 package org.terasology.ligthandshadow.componentsystem.controllers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.Event;
@@ -29,7 +27,6 @@ import org.terasology.module.inventory.events.InventorySlotChangedEvent;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class AttackSystem extends BaseComponentSystem {
-    private static final Logger logger = LoggerFactory.getLogger(AttackSystem.class);
 
     @In
     EntityManager entityManager;
@@ -56,9 +53,6 @@ public class AttackSystem extends BaseComponentSystem {
         if (event.getTarget().exists()
                 && event.getTarget().hasComponent(PlayerCharacterComponent.class)
                 && event.getTarget().hasComponent(HasFlagComponent.class)) {
-
-            logger.info(event.toString());
-            logger.info(item.toFullDescription());
 
             dropFlagOnPlayerAttack(event, event.getTarget());
         }


### PR DESCRIPTION
This PR makes use of the PRs referenced below to turn the magic staff weapon into an item that is used with "item activation", i.e., right click. As the staff is supposed to be used on range against another player this use case needs to be supported by the engine.

It improves the game play in the sense that using the staff is now similar to using the bow or the fire ball staff instead of a "ranged use" action (as in, opening a door with `e`).

- the staff's effect currently is instant. if we want to nerf it in the future, e.g., by requiring a player to track the enemy flag bearer for some time _t_, how can we do this with the technical foundation we have here? does the activation event help here, or do we need something different?

Depends on MovingBlocks/Terasology#4818
Depends on Terasology/LightAndShadowResources#70
