### PR TITLE
fix: Destroy magic barriers and make players vulnerable on headless servers

### DIFF
--- a/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
@@ -24,6 +24,7 @@ import org.terasology.ligthandshadow.componentsystem.events.DelayedDeactivateBar
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class MagicDomeSystem extends BaseComponentSystem {
+    private static final String DEACTIVATE_BARRIERS_ACTION = "LightAndShadow:deactivateBarriers";
     private static final int PREGAME_ZONE_RADIUS = 20;
     @In
     private EntityManager entityManager;
@@ -52,12 +53,12 @@ public class MagicDomeSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void delayedDeactivateBarriers(DelayedDeactivateBarrierEvent event, EntityRef entity) {
-        delayManager.addDelayedAction(entity, "deactivate", 30000);
+        delayManager.addDelayedAction(entity, DEACTIVATE_BARRIERS_ACTION, event.getDelay());
     }
 
     @ReceiveEvent
     public void deactivateBarriers(DelayedActionTriggeredEvent event, EntityRef entity) {
-        if (event.getActionId().equals("deactivate")) {
+        if (event.getActionId().equals(DEACTIVATE_BARRIERS_ACTION)) {
             redBarrier.destroy();
             blackBarrier.destroy();
         }

--- a/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
@@ -19,6 +19,7 @@ import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.lightandshadowresources.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
+import org.terasology.ligthandshadow.componentsystem.components.InvulnerableComponent;
 import org.terasology.ligthandshadow.componentsystem.events.ActivateBarrierEvent;
 import org.terasology.ligthandshadow.componentsystem.events.DelayedDeactivateBarrierEvent;
 
@@ -61,6 +62,7 @@ public class MagicDomeSystem extends BaseComponentSystem {
         if (event.getActionId().equals(DEACTIVATE_BARRIERS_ACTION)) {
             redBarrier.destroy();
             blackBarrier.destroy();
+            removePlayerInvulnerableComponents();
         }
     }
 
@@ -85,7 +87,6 @@ public class MagicDomeSystem extends BaseComponentSystem {
                 Vector3f impulse = position.normalize();
                 impulse.mul(8);
                 player.send(new CharacterImpulseEvent(impulse));
-
                 player.send(new PlaySoundEvent(domeEntity.getComponent(MagicDome.class).hitSound, 2f));
 
             }
@@ -107,5 +108,12 @@ public class MagicDomeSystem extends BaseComponentSystem {
         String barrierTeam = barrier.getComponent(MagicDome.class).team;
         String playerTeam = player.getComponent(LASTeamComponent.class).team;
         return barrierTeam.equals(playerTeam);
+    }
+
+    private void removePlayerInvulnerableComponents() {
+        Iterable<EntityRef> players = entityManager.getEntitiesWith(InvulnerableComponent.class);
+        for (EntityRef player : players) {
+            player.removeComponent(InvulnerableComponent.class);
+        }
     }
 }

--- a/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/barrier/MagicDomeSystem.java
@@ -13,18 +13,22 @@ import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.logic.characters.CharacterImpulseEvent;
 import org.terasology.engine.logic.characters.CharacterMoveInputEvent;
+import org.terasology.engine.logic.delay.DelayManager;
+import org.terasology.engine.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.lightandshadowresources.components.LASTeamComponent;
 import org.terasology.ligthandshadow.componentsystem.LASUtils;
 import org.terasology.ligthandshadow.componentsystem.events.ActivateBarrierEvent;
-import org.terasology.ligthandshadow.componentsystem.events.DeactivateBarrierEvent;
+import org.terasology.ligthandshadow.componentsystem.events.DelayedDeactivateBarrierEvent;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class MagicDomeSystem extends BaseComponentSystem {
     private static final int PREGAME_ZONE_RADIUS = 20;
     @In
     private EntityManager entityManager;
+    @In
+    DelayManager delayManager;
 
     private Vector3f position = new Vector3f();
     private EntityRef redBarrier = EntityRef.NULL;
@@ -47,9 +51,16 @@ public class MagicDomeSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent
-    public void deactivateBarriers(DeactivateBarrierEvent event, EntityRef entity) {
-        redBarrier.destroy();
-        blackBarrier.destroy();
+    public void delayedDeactivateBarriers(DelayedDeactivateBarrierEvent event, EntityRef entity) {
+        delayManager.addDelayedAction(entity, "deactivate", 30000);
+    }
+
+    @ReceiveEvent
+    public void deactivateBarriers(DelayedActionTriggeredEvent event, EntityRef entity) {
+        if (event.getActionId().equals("deactivate")) {
+            redBarrier.destroy();
+            blackBarrier.destroy();
+        }
     }
 
 

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientPregameSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientPregameSystem.java
@@ -75,7 +75,6 @@ public class ClientPregameSystem extends BaseComponentSystem {
                     }
                     if (timePeriod < 0) {
                         window.removeNotification("The game starts in " + (timePeriod + 1) + " seconds.");
-                        removePlayerInvulnerableComponents();
                         timer.cancel();
                     }
                 }
@@ -83,10 +82,5 @@ public class ClientPregameSystem extends BaseComponentSystem {
         }
     }
 
-    private void removePlayerInvulnerableComponents() {
-        Iterable<EntityRef> players = entityManager.getEntitiesWith(InvulnerableComponent.class);
-        for (EntityRef player : players) {
-            player.removeComponent(InvulnerableComponent.class);
-        }
-    }
+
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientPregameSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/ClientPregameSystem.java
@@ -13,7 +13,6 @@ import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.NUIManager;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.ligthandshadow.componentsystem.components.InvulnerableComponent;
-import org.terasology.ligthandshadow.componentsystem.events.DeactivateBarrierEvent;
 import org.terasology.ligthandshadow.componentsystem.events.GameStartMessageEvent;
 import org.terasology.ligthandshadow.componentsystem.events.TimerEvent;
 import org.terasology.notify.ui.DialogNotificationOverlay;
@@ -76,7 +75,6 @@ public class ClientPregameSystem extends BaseComponentSystem {
                     }
                     if (timePeriod < 0) {
                         window.removeNotification("The game starts in " + (timePeriod + 1) + " seconds.");
-                        entity.send(new DeactivateBarrierEvent());
                         removePlayerInvulnerableComponents();
                         timer.cancel();
                     }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -27,6 +27,7 @@ import org.terasology.engine.logic.players.SetDirectionEvent;
 import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.utilities.Assets;
 import org.terasology.ligthandshadow.componentsystem.components.LASConfigComponent;
+import org.terasology.ligthandshadow.componentsystem.events.DelayedDeactivateBarrierEvent;
 import org.terasology.ligthandshadow.componentsystem.events.GameStartMessageEvent;
 import org.terasology.ligthandshadow.componentsystem.events.PregameEvent;
 import org.terasology.ligthandshadow.componentsystem.events.TimerEvent;
@@ -103,6 +104,7 @@ public class TeleporterSystem extends BaseComponentSystem {
         if (teleporterTeamCount - oppositeTeamCount < maxTeamSizeDifference) {
             if (teleporterTeamCount >= 0 && oppositeTeamCount >= 1 && !gameStart) {
                 sendEventToClients(TimerEvent::new);
+                player.send(new DelayedDeactivateBarrierEvent());
                 gameStart = true;
             }
             return true;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/controllers/TeleporterSystem.java
@@ -104,7 +104,7 @@ public class TeleporterSystem extends BaseComponentSystem {
         if (teleporterTeamCount - oppositeTeamCount < maxTeamSizeDifference) {
             if (teleporterTeamCount >= 0 && oppositeTeamCount >= 1 && !gameStart) {
                 sendEventToClients(TimerEvent::new);
-                player.send(new DelayedDeactivateBarrierEvent());
+                player.send(new DelayedDeactivateBarrierEvent(30000));
                 gameStart = true;
             }
             return true;

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/DelayedDeactivateBarrierEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/DelayedDeactivateBarrierEvent.java
@@ -3,9 +3,11 @@
 package org.terasology.ligthandshadow.componentsystem.events;
 
 import org.terasology.engine.entitySystem.event.Event;
+import org.terasology.engine.network.ServerEvent;
 
 /**
  * Trigger event to deactivate the pregame barriers.
  */
-public class DeactivateBarrierEvent implements Event {
+@ServerEvent
+public class DelayedDeactivateBarrierEvent implements Event {
 }

--- a/src/main/java/org/terasology/ligthandshadow/componentsystem/events/DelayedDeactivateBarrierEvent.java
+++ b/src/main/java/org/terasology/ligthandshadow/componentsystem/events/DelayedDeactivateBarrierEvent.java
@@ -10,4 +10,13 @@ import org.terasology.engine.network.ServerEvent;
  */
 @ServerEvent
 public class DelayedDeactivateBarrierEvent implements Event {
+    private int delay;
+
+    public DelayedDeactivateBarrierEvent(int delay) {
+        this.delay = delay;
+    }
+
+    public int getDelay() {
+        return delay;
+    }
 }


### PR DESCRIPTION
There does seem to be a 1-2 seconds delay between the UI and the destruction of the barrier. Not sure how to test this on a headless server.