### PR TITLE
feat: making players invulnerable before game round starts

### DIFF
--- a/deltas/engine/prefabs/player/player.prefab
+++ b/deltas/engine/prefabs/player/player.prefab
@@ -1,10 +1,11 @@
 {
-    "Character": {
-        "nameTagOffset": 1.7
-    },
-    "LASTeam" : {
-        "team" : "white"
-    },
-    "FlagDropOnActivate" : {},
-    "PlayerStatistics" : {}
+  "Character": {
+    "nameTagOffset": 1.7
+  },
+  "LASTeam": {
+    "team": "white"
+  },
+  "Invulnerable": {},
+  "FlagDropOnActivate": {},
+  "PlayerStatistics": {}
 }


### PR DESCRIPTION
This PR adds `InvulnerableComponent` to the players before the match to prevent the players from accidentally dying or killing each other before the actual game rounds start
