### PR TITLE
fix: prevent npe on player death by thrown spear

### DIFF
--- a/src/main/java/org/terasology/module/lightandshadow/systems/ClientPregameSystem.java
+++ b/src/main/java/org/terasology/module/lightandshadow/systems/ClientPregameSystem.java
@@ -26,6 +26,8 @@ public class ClientPregameSystem extends BaseComponentSystem {
 
     private static final String PREGAME_MESSAGE = "The game start's as soon as there is \n at least one player in each team.";
 
+    private static final int COUNTDOWN_IN_SECONDS = 30;
+
     private static Timer timer;
 
     @In
@@ -60,7 +62,7 @@ public class ClientPregameSystem extends BaseComponentSystem {
         if (localPlayer.getClientEntity().equals(entity)) {
             timer = new Timer();
             timer.scheduleAtFixedRate(new TimerTask() {
-                int timePeriod = 30;
+                int timePeriod = COUNTDOWN_IN_SECONDS;
                 boolean addNotification;
                 public void run() {
                     if (addNotification) {

--- a/src/main/java/org/terasology/module/lightandshadow/systems/ClientPregameSystem.java
+++ b/src/main/java/org/terasology/module/lightandshadow/systems/ClientPregameSystem.java
@@ -15,7 +15,6 @@ import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.input.InputSystem;
 import org.terasology.engine.logic.players.LocalPlayer;
-import org.terasology.engine.logic.players.event.LocalPlayerInitializedEvent;
 import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.NUIManager;

--- a/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
@@ -43,17 +43,17 @@ public class PlayerDeathSystem extends BaseComponentSystem {
     @In
     private InventoryManager inventoryManager;
 
-    private Random random = new Random();
+    private static final Random random = new Random();
 
     /**
-     * Reset the inventory and send player player back to its base with refilled health.
+     * Reset the inventory and send the player back to its base with refilled health.
      * This is a high priority method, hence it receives the event first and consumes it.
      * This prevents the destruction of player entity and prevents the deathScreen from showing up.
      *
-     * @param event
-     * @param player
-     * @param characterComponent
-     * @param aliveCharacterComponent
+     * @param event notification event that a player entity is about to be destroyed (usually sent on death)
+     * @param player the player entity about to be destroyed
+     * @param characterComponent ensures that the entity has a character (TODO: why do we need this?)
+     * @param aliveCharacterComponent ensures that the player is currently alive (TODO: parameter not used, move to annotion?)
      */
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void beforeDestroy(BeforeDestroyEvent event, EntityRef player,

--- a/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
@@ -37,13 +37,13 @@ import org.terasology.lightandshadowresources.components.LASTeamComponent;
  */
 @RegisterSystem
 public class PlayerDeathSystem extends BaseComponentSystem {
+    private static final Random RANDOM = new Random();
+
     Optional<Prefab> prefab = Assets.getPrefab("inventory");
     StartingInventoryComponent startingInventory = prefab.get().getComponent(StartingInventoryComponent.class);
 
     @In
     private InventoryManager inventoryManager;
-
-    private static final Random random = new Random();
 
     /**
      * Reset the inventory and send the player back to its base with refilled health.
@@ -72,7 +72,7 @@ public class PlayerDeathSystem extends BaseComponentSystem {
             updateStatistics(player, StatisticType.DEATHS);
             dropItemsFromInventory(player);
             player.send(new RestoreFullHealthEvent(player));
-            Vector3f randomVector = new Vector3f(-1 + random.nextInt(3), 0, -1 + random.nextInt(3));
+            Vector3f randomVector = new Vector3f(-1 + RANDOM.nextInt(3), 0, -1 + RANDOM.nextInt(3));
             player.send(new CharacterTeleportEvent(randomVector.add(LASUtils.getTeleportDestination(team))));
 
             player.send(new SetDirectionEvent(LASUtils.getYaw(LASUtils.getTeleportDestination(team).
@@ -107,8 +107,12 @@ public class PlayerDeathSystem extends BaseComponentSystem {
         switch (statisticType) {
             case KILLS:
                 playerStatisticsComponent.kills += 1;
+                break;
             case DEATHS:
                 playerStatisticsComponent.deaths += 1;
+                break;
+            default:
+                return;
         }
         player.saveComponent(playerStatisticsComponent);
     }

--- a/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
+++ b/src/main/java/org/terasology/module/lightandshadow/systems/PlayerDeathSystem.java
@@ -53,7 +53,7 @@ public class PlayerDeathSystem extends BaseComponentSystem {
      * @param event notification event that a player entity is about to be destroyed (usually sent on death)
      * @param player the player entity about to be destroyed
      * @param characterComponent ensures that the entity has a character (TODO: why do we need this?)
-     * @param aliveCharacterComponent ensures that the player is currently alive (TODO: parameter not used, move to annotion?)
+     * @param aliveCharacterComponent ensures that the player is currently alive (TODO: parameter not used, move to annotation?)
      */
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void beforeDestroy(BeforeDestroyEvent event, EntityRef player,


### PR DESCRIPTION
Combat system may assign `null` as instigator to some (Before)DestroyEvents which causes an NPE in the player death system.

This fixes the crash with a `TODO` item to find and fix the root cause. See https://github.com/Terasology/CombatSystem/pull/92 for first investigation results.

In addition, this commit introduces an enum for the statistics type to update to avoid any bugs resulting from using plain string "constants" (we did not even use constants ...).

Furthermore, I've made the pre-game countdown a constant. This should make it easier to find this value and adjust it later, e.g., for local testing or tweaking.
