### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/module/lightandshadow/world/platform/FloatingPlatformProvider.java
+++ b/src/main/java/org/terasology/module/lightandshadow/world/platform/FloatingPlatformProvider.java
@@ -98,7 +98,7 @@ public class FloatingPlatformProvider implements ConfigurableFacetProvider, Face
         this.configuration = (Config) configuration;
     }
 
-    private static class Config implements Component<Config> {
+    public static class Config implements Component<Config> {
 //        @Range(min = 10, max = 1000, increment = 1, precision = 0, label = "Platform Height")
 //        public int height = 100;
 


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191